### PR TITLE
test: add playwright e2e tests for auth

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,8 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  transformIgnorePatterns: ['/node_modules/(?!lucide-react)']
+  transformIgnorePatterns: ['/node_modules/(?!lucide-react)'],
+  testPathIgnorePatterns: ['<rootDir>/tests/']
 }
 
 module.exports = createJestConfig(customJestConfig)

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
         "@testing-library/user-event": "^14.4.3",
@@ -5917,6 +5918,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -17469,6 +17486,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.14.1",
@@ -58,20 +59,21 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "genkit-cli": "^1.14.1",
-    "postcss": "^8",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5",
+    "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.12",
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^15.3.3",
+    "genkit-cli": "^1.14.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "eslint": "^8.57.0",
-    "eslint-config-next": "^15.3.3"
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:9002',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:9002',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+// Credentials defined in AGENTS.md
+const EMAIL = 'test@test.com';
+const PASSWORD = 'test';
+
+test('user can log in with valid credentials', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[id="email"]', EMAIL);
+  await page.fill('input[id="password"]', PASSWORD);
+  await page.click('button[type="submit"]');
+
+  // Expect to navigate to the home page and see the Sign Out button
+  await expect(page).toHaveURL('/');
+  await expect(page.getByRole('button', { name: 'Sign Out' })).toBeVisible();
+});

--- a/tests/register.spec.ts
+++ b/tests/register.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+// Use a unique email so repeated runs don't conflict
+function uniqueEmail() {
+  return `user${Date.now()}@test.com`;
+}
+
+test('user can register a new account', async ({ page }) => {
+  await page.goto('/register');
+  await page.fill('input[id="email"]', uniqueEmail());
+  await page.fill('input[id="password"]', 'test');
+  await page.click('button[type="submit"]');
+
+  // After successful registration, the app redirects to the login page
+  await expect(page).toHaveURL(/\/login$/);
+});


### PR DESCRIPTION
## Summary
- add Playwright setup
- cover register and login flows with Playwright
- keep Playwright specs out of Jest runs

## Testing
- `npm test`
- `npm run e2e` *(fails: Error: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bca1c671d4832e8a39ddfb1ce53d2d