### PR TITLE
Add setup script to generate .env.local for tests

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Your other setup commands (e.g., npm install) go here
+
+# Write the secrets to a .env.local file
+# The '>>' appends to the file, which is safer than '>' overwriting it.
+echo "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}" >> .env.local
+echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}" >> .env.local
+
+echo "Successfully created .env.local for the test run."


### PR DESCRIPTION
## Summary
- add `setup.sh` to create `.env.local` using Supabase environment variables

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcac31b7e4832e86fc7b61e56074e3