### PR TITLE
Add Playwright e2e tests for auth flows

### DIFF
--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from 'playwright/test';
+
+test('user can log in', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('test@test.com');
+  await page.getByLabel('Password').fill('test');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL('/');
+  await expect(page.getByRole('button', { name: 'Sign Out' })).toBeVisible();
+});

--- a/e2e/register.spec.ts
+++ b/e2e/register.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from 'playwright/test';
+
+test('user can register', async ({ page }) => {
+  const email = `user${Date.now()}@example.com`;
+  const password = 'test1234';
+
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Create Account' }).click();
+  await expect(page).toHaveURL('/login');
+  await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.14.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:9002',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 9002,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Playwright with a dev web server
- add e2e tests for user registration and login

## Testing
- `npx playwright install --with-deps`
- `npx playwright test` *(fails: registration stays on /register and login fails)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbee6092c832ea0bc9c0123037f4d