### PR TITLE
Exclude e2e tests from npm test target

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,8 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  transformIgnorePatterns: ['/node_modules/(?!lucide-react)']
+  transformIgnorePatterns: ['/node_modules/(?!lucide-react)'],
+  testPathIgnorePatterns: ['<rootDir>/e2e/']
 }
 
 module.exports = createJestConfig(customJestConfig)


### PR DESCRIPTION
## Summary
- prevent Jest from executing Playwright e2e specs

## Testing
- `npm test`
- `npm run test:e2e` *(fails: page.goto net::ERR_ABORTED; maybe frame was detached?)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc2fe7614832eb96ab7ce09005cdc