### PR TITLE
feat: Add initial structure for Yahoo Fantasy Football integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,34 @@ This project uses [Supabase](https://supabase.com) for authentication. Provide t
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
 You can sign in at `/login` with an email and password, sign up for a new account at `/register`, and sign out from the main page header.
+
+## Yahoo Fantasy Football Integration
+
+A basic structure for Yahoo Fantasy Football integration has been added. To complete the implementation, follow these steps:
+
+### TODO
+
+1.  **Register a new application with Yahoo:**
+    *   Go to the [Yahoo Developer Network](https://developer.yahoo.com/apps/create/) and create a new application.
+    *   Set the "Callback Domain" to your application's domain.
+    *   Select "Fantasy Sports" as the API permission, with "Read" or "Read/Write" access.
+    *   Once you have created the application, you will get a "Client ID" and "Client Secret".
+
+2.  **Set up environment variables:**
+    *   Create a `.env.local` file in the root of the project.
+    *   Add the following environment variables to the file:
+        ```
+        YAHOO_CLIENT_ID=<your_yahoo_client_id>
+        YAHOO_CLIENT_SECRET=<your_yahoo_client_secret>
+        ```
+
+3.  **Implement the OAuth 2.0 flow:**
+    *   Update the `handleConnect` function in `src/app/integrations/yahoo/page.tsx` to redirect the user to the Yahoo authorization URL.
+    *   Update the `src/app/api/auth/yahoo/route.ts` file to handle the callback from Yahoo. This includes:
+        *   Exchanging the authorization code for an access token.
+        *   Storing the access token, refresh token, and other relevant information in the `user_integrations` table in the database.
+    *   Update the `connectYahoo` function in `src/app/integrations/yahoo/actions.ts` to use the access token to fetch the user's information from the Yahoo API.
+
+4.  **Implement the API calls to fetch data:**
+    *   Update the `getYahooLeagues` function in `src/app/integrations/yahoo/actions.ts` to fetch the user's leagues from the Yahoo Fantasy Sports API. You will need to use the access token to make authenticated requests.
+    *   Implement a function to fetch players from a team's roster.

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8.57.0",
-        "eslint-config-next": "^15.3.3",
+        "eslint-config-next": "15.3.3",
         "genkit-cli": "^1.14.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -4318,9 +4318,9 @@
       "integrity": "sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.2.tgz",
-      "integrity": "sha512-lkLrRVxcftuOsJNhWatf1P2hNVfh98k/omQHrCEPPriUypR6RcS13IvLdIrEvkm9AH2Nu2YpR5vLqBuy6twH3Q==",
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.3.tgz",
+      "integrity": "sha512-VKZJEiEdpKkfBmcokGjHu0vGDG+8CehGs90tBEy/IDoDDKGngeyIStt2MmE5FYNyU9BhgR7tybNWTAJY/30u+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11430,13 +11430,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.2.tgz",
-      "integrity": "sha512-3hPZghsLupMxxZ2ggjIIrat/bPniM2yRpsVPVM40rp8ZMzKWOJp2CGWn7+EzoV2ddkUr5fxNfHpF+wU1hGt/3g==",
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.3.tgz",
+      "integrity": "sha512-QJLv/Ouk2vZnxL4b67njJwTLjTf7uZRltI0LL4GERYR4qMF5z08+gxkfODAeaK7TiC6o+cER91bDaEnwrTWV6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.2",
+        "@next/eslint-plugin-next": "15.3.3",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -16338,6 +16338,7 @@
       "version": "15.3.3",
       "resolved": "https://registry.npmjs.org/next/-/next-15.3.3.tgz",
       "integrity": "sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==",
+      "license": "MIT",
       "dependencies": {
         "@next/env": "15.3.3",
         "@swc/counter": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8.57.0",
-    "eslint-config-next": "^15.3.3",
+    "eslint-config-next": "15.3.3",
     "genkit-cli": "^1.14.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/src/app/api/auth/yahoo/route.ts
+++ b/src/app/api/auth/yahoo/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  // This is a placeholder for the Yahoo OAuth callback.
+  // In a real application, you would handle the OAuth callback here,
+  // exchanging the authorization code for an access token and storing it.
+  return NextResponse.json({ message: 'Yahoo OAuth callback received' });
+}

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -11,13 +11,23 @@ export default function IntegrationsPage() {
             Connect your fantasy football accounts to get started.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Link href="/integrations/sleeper">
             <Card className="hover:bg-muted">
               <CardHeader>
                 <CardTitle>Sleeper</CardTitle>
                 <CardDescription>
                   Connect your Sleeper account to import your leagues.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+          <Link href="/integrations/yahoo">
+            <Card className="hover:bg-muted">
+              <CardHeader>
+                <CardTitle>Yahoo</CardTitle>
+                <CardDescription>
+                  Connect your Yahoo account to import your leagues.
                 </CardDescription>
               </CardHeader>
             </Card>

--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -1,0 +1,94 @@
+'use server';
+
+import { createClient } from '@/utils/supabase/server';
+
+export async function connectYahoo() {
+  // This will be replaced with the actual OAuth flow
+  const supabase = createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in to connect your Yahoo account.' };
+  }
+
+  const { error: insertError } = await supabase
+    .from('user_integrations')
+    .insert({
+      user_id: user.id,
+      provider: 'yahoo',
+      provider_user_id: 'mock_yahoo_user_id', // This will be replaced with the actual Yahoo user ID
+    });
+
+  if (insertError) {
+    return { error: insertError.message };
+  }
+
+  return { success: true };
+}
+
+export async function removeYahooIntegration(integrationId: number) {
+  const supabase = createClient();
+
+  // First, delete all leagues associated with the integration
+  const { error: deleteLeaguesError } = await supabase
+    .from('leagues')
+    .delete()
+    .eq('user_integration_id', integrationId);
+
+  if (deleteLeaguesError) {
+    return { error: `Failed to delete leagues: ${deleteLeaguesError.message}` };
+  }
+
+  // Then, delete the integration itself
+  const { error: deleteIntegrationError } = await supabase
+    .from('user_integrations')
+    .delete()
+    .eq('id', integrationId);
+
+  if (deleteIntegrationError) {
+    return { error: `Failed to delete integration: ${deleteIntegrationError.message}` };
+  }
+
+  return { success: true };
+}
+
+export async function getLeagues(integrationId: number) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('leagues')
+    .select('*')
+    .eq('user_integration_id', integrationId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { leagues: data };
+}
+
+export async function getYahooIntegration() {
+  const supabase = createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in.' };
+  }
+
+  const { data, error } = await supabase
+    .from('user_integrations')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('provider', 'yahoo')
+    .single();
+
+  if (error && error.code !== 'PGRST116') { // ignore no rows found error
+    return { error: error.message };
+  }
+
+  return { integration: data };
+}
+
+export async function getYahooLeagues(integrationId: number) {
+  // This will be replaced with the actual API call to Yahoo
+  return { leagues: [] };
+}

--- a/src/app/integrations/yahoo/page.tsx
+++ b/src/app/integrations/yahoo/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getYahooIntegration, getLeagues, removeYahooIntegration } from './actions';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function YahooPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [leagues, setLeagues] = useState<any[]>([]);
+  const [integration, setIntegration] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  useEffect(() => {
+    const checkIntegration = async () => {
+      const { integration, error } = await getYahooIntegration();
+      if (error) {
+        setError(error);
+      } else {
+        setIntegration(integration);
+      }
+      setLoading(false);
+    };
+    checkIntegration();
+  }, []);
+
+  const handleConnect = () => {
+    // The OAuth flow will be initiated here.
+    // For now, we'll just log a message to the console.
+    console.log('Initiating Yahoo OAuth flow...');
+  };
+
+  const handleRemove = async () => {
+    if (!integration) return;
+
+    setIsRemoving(true);
+    setError(null);
+
+    const { success, error } = await removeYahooIntegration(integration.id);
+
+    if (error) {
+      setError(error);
+    } else if (success) {
+      setIntegration(null);
+      setLeagues([]);
+    }
+
+    setIsRemoving(false);
+  };
+
+  useEffect(() => {
+    if (integration) {
+      const fetchLeagues = async () => {
+        // First, try to get leagues from our DB
+        const dbResponse = await getLeagues(integration.id);
+
+        if (dbResponse.error) {
+          setError(dbResponse.error);
+          return;
+        }
+        if (dbResponse.leagues && dbResponse.leagues.length > 0) {
+          setLeagues(dbResponse.leagues);
+          return;
+        }
+
+        // If no leagues in DB, fetch from Yahoo API and persist
+        // This will be implemented later
+        // const yahooResponse = await getYahooLeagues(integration.id);
+        // if (yahooResponse.error) {
+        //   setError(yahooResponse.error);
+        // } else {
+        //   setLeagues(yahooResponse.leagues || []);
+        // }
+      };
+      fetchLeagues();
+    }
+  }, [integration]);
+
+  if (loading) {
+    return <main className="p-4">Loading...</main>;
+  }
+
+  return (
+    <main className="p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Connect to Yahoo</CardTitle>
+          <CardDescription>
+            {integration
+              ? "You have successfully connected your Yahoo account."
+              : "Click the button below to connect your Yahoo account."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!integration ? (
+            <Button onClick={handleConnect}>Connect Yahoo</Button>
+          ) : (
+            <div>
+              <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
+                {isRemoving ? 'Removing...' : 'Remove Integration'}
+              </Button>
+            </div>
+          )}
+          {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+          {leagues.length > 0 && (
+            <div className="mt-4">
+              <h3 className="text-lg font-medium">Your Leagues</h3>
+              <ul className="mt-2 space-y-2">
+                {leagues.map((league) => (
+                  <li key={league.league_id} className="p-2 border rounded-md">
+                    {league.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/supabase/migrations/20250906220000_add_oauth_tokens_to_user_integrations.sql
+++ b/supabase/migrations/20250906220000_add_oauth_tokens_to_user_integrations.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_integrations
+ADD COLUMN access_token TEXT,
+ADD COLUMN refresh_token TEXT,
+ADD COLUMN token_type TEXT;


### PR DESCRIPTION
This change adds the basic structure for integrating with Yahoo Fantasy Football. It includes:

- A new page for the Yahoo integration at /integrations/yahoo.
- Server-side actions and a placeholder API route for handling the OAuth flow.
- A database migration to add columns for storing OAuth tokens.
- Instructions in the README.md file for completing the implementation.