### PR TITLE
Ensure e2e tests only delete their own users

### DIFF
--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -13,8 +13,9 @@ test('user can log in', async ({ page }) => {
   );
 
   try {
-    const { data: existing } = await supabase.auth.admin.listUsers({ email });
-    const existingUser = existing.users?.[0];
+    const {
+      data: { user: existingUser },
+    } = await supabase.auth.admin.getUserByEmail(email);
     if (existingUser) {
       await supabase.auth.admin.deleteUser(existingUser.id);
     }
@@ -32,8 +33,9 @@ test('user can log in', async ({ page }) => {
     await expect(page).toHaveURL('/');
     await expect(page.getByRole('button', { name: 'Sign Out' })).toBeVisible();
   } finally {
-    const { data } = await supabase.auth.admin.listUsers({ email });
-    const user = data.users?.[0];
+    const {
+      data: { user },
+    } = await supabase.auth.admin.getUserByEmail(email);
     if (user) {
       await supabase.auth.admin.deleteUser(user.id);
     }

--- a/e2e/register.spec.ts
+++ b/e2e/register.spec.ts
@@ -22,8 +22,9 @@ test('user can register', async ({ page }) => {
     await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
   } finally {
     if (supabase) {
-      const { data } = await supabase.auth.admin.listUsers({ email });
-      const user = data.users?.[0];
+      const {
+        data: { user },
+      } = await supabase.auth.admin.getUserByEmail(email);
       if (user) {
         await supabase.auth.admin.deleteUser(user.id);
       }


### PR DESCRIPTION
## Summary
- use `getUserByEmail` in e2e tests so cleanup only removes targeted accounts

## Testing
- `npm test`
- `npm run test:e2e` *(fails: expect(page).toHaveURL('/login') received '/register')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bd0e9c87b8832eb85a851739fd253d