### PR TITLE
fix(yahoo): Pass cookie store to Supabase server client

### DIFF
--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -4,7 +4,8 @@ import { cookies } from 'next/headers';
 import { createClient } from '@/utils/supabase/server';
 
 async function getYahooAccessToken(integrationId: number): Promise<{ access_token?: string; error?: string }> {
-  const supabase = createClient();
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
   console.log(`Fetching access token for integrationId: ${integrationId}`);
 
   const { data: { user } } = await supabase.auth.getUser();
@@ -147,7 +148,8 @@ export async function getLeagues(integrationId: number) {
 }
 
 export async function getTeams(integrationId: number) {
-  const supabase = createClient();
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
   const { data, error } = await supabase
     .from('teams')
     .select('*')
@@ -210,7 +212,8 @@ export async function getYahooUserTeams(integrationId: number) {
     });
 
     if (teamsToInsert.length > 0) {
-      const supabase = createClient();
+      const cookieStore = cookies();
+      const supabase = createClient(cookieStore);
       const { data: insertedTeams, error: insertError } = await supabase
         .from('teams')
         .upsert(teamsToInsert, { onConflict: 'team_key' })
@@ -293,7 +296,8 @@ export async function getYahooLeagues(integrationId: number) {
     }));
 
     if (leaguesToInsert.length > 0) {
-      const supabase = createClient();
+      const cookieStore = cookies();
+      const supabase = createClient(cookieStore);
       const { data: insertedLeagues, error: insertError } = await supabase
         .from('leagues')
         .insert(leaguesToInsert)


### PR DESCRIPTION
The Supabase server client was being initialized without the necessary cookie store in several server actions related to the Yahoo integration. This caused a `TypeError: Cannot read properties of undefined (reading 'get')` during server-side rendering and execution of these actions.

This commit fixes the issue by ensuring that the `cookies()` object from `next/headers` is passed to the `createClient` function in all relevant places within `src/app/integrations/yahoo/actions.ts`. This allows the Supabase client to correctly handle user sessions on the server.