### PR TITLE
fix playwright workflow install step

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npx playwright install --with-deps
       - run: npm run test:e2e
         env:


### PR DESCRIPTION
## Summary
- use `npm install` in Playwright GitHub workflow to avoid lockfile errors during CI

## Testing
- `npm test`
- `npm run test:e2e` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a1ef03a4832e9a9c8473f6f3d03d