### PR TITLE
Specify locale for alert timestamps

### DIFF
--- a/src/components/integration-status.tsx
+++ b/src/components/integration-status.tsx
@@ -69,7 +69,7 @@ export function IntegrationStatus() {
                                 <span className="mt-0.5">{alertIcons[alert.type]}</span>
                                 <div className="flex-1">
                                     <p className="text-sm">{alert.message}</p>
-                                    <p className="text-xs text-muted-foreground">{new Date(alert.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</p>
+                                    <p className="text-xs text-muted-foreground">{new Date(alert.timestamp).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}</p>
                                 </div>
                             </div>
                         ))}


### PR DESCRIPTION
## Summary
- ensure alert log timestamps use a consistent 'en-US' locale

## Testing
- `npm test`
- `npm run test:e2e` *(fails: ENETUNREACH: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a7735d84832ea7296aa589ebcf54