### PR TITLE
feat: add reusable fetchJson helper

### DIFF
--- a/src/app/integrations/sleeper/actions.test.ts
+++ b/src/app/integrations/sleeper/actions.test.ts
@@ -1,0 +1,23 @@
+import { getMatchups } from './actions';
+import { fetchJson } from '@/lib/fetch-json';
+
+jest.mock('@/lib/fetch-json', () => ({ fetchJson: jest.fn() }));
+
+describe('sleeper actions', () => {
+  beforeEach(() => {
+    (fetchJson as jest.Mock).mockReset();
+  });
+
+  it('returns matchups on success', async () => {
+    (fetchJson as jest.Mock).mockResolvedValue({ data: [{ id: 1 }] });
+    const result = await getMatchups('league', '1');
+    expect(fetchJson).toHaveBeenCalledWith('https://api.sleeper.app/v1/league/league/matchups/1');
+    expect(result).toEqual({ matchups: [{ id: 1 }] });
+  });
+
+  it('returns error on failure', async () => {
+    (fetchJson as jest.Mock).mockResolvedValue({ error: 'fail' });
+    const result = await getMatchups('league', '1');
+    expect(result).toEqual({ error: 'fail' });
+  });
+});

--- a/src/app/integrations/sleeper/actions.ts
+++ b/src/app/integrations/sleeper/actions.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from 'next/headers';
 import { createClient } from '@/utils/supabase/server';
+import { fetchJson } from '@/lib/fetch-json';
 
 /**
  * Connects a Sleeper account to the user's account.
@@ -17,12 +18,10 @@ export async function connectSleeper(username: string) {
   }
 
   try {
-    const res = await fetch(`https://api.sleeper.app/v1/user/${username}`);
-    if (!res.ok) {
-      const error = await res.json();
-      return { error: error.message || 'Failed to fetch user' };
+    const { data: sleeperUser, error } = await fetchJson<any>(`https://api.sleeper.app/v1/user/${username}`);
+    if (error) {
+      return { error: error || 'Failed to fetch user' };
     }
-    const sleeperUser = await res.json();
     if (!sleeperUser) {
       return { error: 'User not found' };
     }
@@ -131,12 +130,10 @@ export async function getSleeperLeagues(userId: string, integrationId: number) {
   const supabase = createClient();
   try {
     const year = new Date().getFullYear();
-    const res = await fetch(`https://api.sleeper.app/v1/user/${userId}/leagues/nfl/${year}`);
-    if (!res.ok) {
-      const error = await res.json();
-      return { error: error.message || 'Failed to fetch leagues' };
+    const { data: leagues, error } = await fetchJson<any[]>(`https://api.sleeper.app/v1/user/${userId}/leagues/nfl/${year}`);
+    if (error) {
+      return { error };
     }
-    const leagues = await res.json();
 
     if (leagues && leagues.length > 0) {
       const leaguesToInsert = leagues.map((league: any) => ({
@@ -168,12 +165,10 @@ export async function getSleeperLeagues(userId: string, integrationId: number) {
  */
 export async function getMatchups(leagueId: string, week: string) {
   try {
-    const res = await fetch(`https://api.sleeper.app/v1/league/${leagueId}/matchups/${week}`);
-    if (!res.ok) {
-      const error = await res.json();
-      return { error: error.message || 'Failed to fetch matchups' };
+    const { data: matchups, error } = await fetchJson<any[]>(`https://api.sleeper.app/v1/league/${leagueId}/matchups/${week}`);
+    if (error) {
+      return { error };
     }
-    const matchups = await res.json();
     return { matchups };
   } catch (error) {
     return { error: 'An unexpected error occurred' };
@@ -187,12 +182,10 @@ export async function getMatchups(leagueId: string, week: string) {
  */
 export async function getRosters(leagueId: string) {
   try {
-    const res = await fetch(`https://api.sleeper.app/v1/league/${leagueId}/rosters`);
-    if (!res.ok) {
-      const error = await res.json();
-      return { error: error.message || 'Failed to fetch rosters' };
+    const { data: rosters, error } = await fetchJson<any[]>(`https://api.sleeper.app/v1/league/${leagueId}/rosters`);
+    if (error) {
+      return { error };
     }
-    const rosters = await res.json();
     return { rosters };
   } catch (error) {
     return { error: 'An unexpected error occurred' };
@@ -206,12 +199,10 @@ export async function getRosters(leagueId: string) {
  */
 export async function getUsersInLeague(leagueId: string) {
   try {
-    const res = await fetch(`https://api.sleeper.app/v1/league/${leagueId}/users`);
-    if (!res.ok) {
-      const error = await res.json();
-      return { error: error.message || 'Failed to fetch users' };
+    const { data: users, error } = await fetchJson<any[]>(`https://api.sleeper.app/v1/league/${leagueId}/users`);
+    if (error) {
+      return { error };
     }
-    const users = await res.json();
     return { users };
   } catch (error) {
     return { error: 'An unexpected error occurred' };
@@ -224,12 +215,10 @@ export async function getUsersInLeague(leagueId: string) {
  */
 export async function getNflPlayers() {
   try {
-    const res = await fetch(`https://api.sleeper.app/v1/players/nfl`);
-    if (!res.ok) {
-      const error = await res.json();
-      return { error: error.message || 'Failed to fetch nfl players' };
+    const { data: players, error } = await fetchJson<Record<string, any>>(`https://api.sleeper.app/v1/players/nfl`);
+    if (error) {
+      return { error };
     }
-    const players = await res.json();
     return { players };
   } catch (error) {
     return { error: 'An unexpected error occurred' };

--- a/src/app/integrations/yahoo/actions.test.ts
+++ b/src/app/integrations/yahoo/actions.test.ts
@@ -1,0 +1,42 @@
+import { getYahooAccessToken } from './actions';
+import { fetchJson } from '@/lib/fetch-json';
+import { createClient } from '@/utils/supabase/server';
+
+jest.mock('@/lib/fetch-json', () => ({ fetchJson: jest.fn() }));
+jest.mock('@/utils/supabase/server', () => ({ createClient: jest.fn() }));
+jest.mock('@/utils/logger', () => ({ info: jest.fn(), error: jest.fn(), debug: jest.fn() }));
+
+describe('yahoo actions', () => {
+  const eqChain = jest.fn().mockReturnThis();
+  const eqUpdate = jest.fn().mockResolvedValue({ error: null });
+  const mockSupabase = {
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user' } } }) },
+    from: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: eqChain,
+      single: jest.fn(),
+      update: jest.fn().mockReturnValue({ eq: eqUpdate }),
+    }),
+  } as any;
+
+  beforeEach(() => {
+    (createClient as jest.Mock).mockReturnValue(mockSupabase);
+    mockSupabase.from().single.mockResolvedValue({ data: { access_token: 'old', refresh_token: 'refresh', expires_at: new Date(Date.now() - 1000).toISOString() }, error: null });
+    (fetchJson as jest.Mock).mockReset();
+    process.env.YAHOO_CLIENT_ID = 'id';
+    process.env.YAHOO_CLIENT_SECRET = 'secret';
+    process.env.YAHOO_REDIRECT_URI = 'uri';
+  });
+
+  it('refreshes token successfully', async () => {
+    (fetchJson as jest.Mock).mockResolvedValue({ data: { access_token: 'new', refresh_token: 'r', expires_in: 3600 } });
+    const result = await getYahooAccessToken(1);
+    expect(result).toEqual({ access_token: 'new' });
+  });
+
+  it('returns error when refresh fails', async () => {
+    (fetchJson as jest.Mock).mockResolvedValue({ error: 'bad' });
+    const result = await getYahooAccessToken(1);
+    expect(result).toEqual({ error: 'Failed to refresh Yahoo token: bad' });
+  });
+});

--- a/src/lib/fetch-json.test.ts
+++ b/src/lib/fetch-json.test.ts
@@ -1,0 +1,19 @@
+import { fetchJson } from './fetch-json';
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock) = jest.fn();
+  });
+
+  it('returns data when response is ok', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve({ a: 1 }) });
+    const result = await fetchJson<{ a: number }>('/test');
+    expect(result).toEqual({ data: { a: 1 } });
+  });
+
+  it('returns error when response is not ok', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: false, statusText: 'Bad', json: () => Promise.resolve({ message: 'fail' }) });
+    const result = await fetchJson('/test');
+    expect(result).toEqual({ error: 'fail' });
+  });
+});

--- a/src/lib/fetch-json.ts
+++ b/src/lib/fetch-json.ts
@@ -1,0 +1,20 @@
+export async function fetchJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<{ data?: T; error?: string }> {
+  try {
+    const res = await fetch(input, init);
+    let json: any = null;
+    try {
+      json = await res.json();
+    } catch {
+      json = null;
+    }
+
+    if (!res.ok) {
+      const message = json?.error_description || json?.message || json?.error || res.statusText || 'Failed to fetch';
+      return { error: message };
+    }
+
+    return { data: json as T };
+  } catch (err: any) {
+    return { error: err.message || 'Failed to fetch' };
+  }
+}


### PR DESCRIPTION
## Summary
- add fetchJson utility to wrap fetch with JSON parsing and error handling
- refactor Sleeper and Yahoo actions to use fetchJson
- test helper and updated actions

## Testing
- `npm test`
- `npm run test:e2e` *(fails: ENETUNREACH when contacting Supabase)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e2c0524c832eb211bb560f6c1a29