### PR TITLE
feat: publish per-run Playwright reports

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,16 +41,36 @@ jobs:
         NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 
-    - name: Copy test results to report directory
-      if: always() # Run this even if tests fail
-      run: cp -r test-results/* playwright-report/
+    - name: Prepare run-specific report directory
+      if: always()
+      run: |
+        REPORT_DIR="playwright-report-${{ github.run_id }}"
+        mkdir -p "$REPORT_DIR"
+        cp -r playwright-report/* "$REPORT_DIR/"
+        cp -r test-results "$REPORT_DIR/"
+
+    - name: Checkout existing GitHub Pages
+      if: always()
+      continue-on-error: true
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        path: gh-pages
+
+    - name: Assemble Pages content
+      if: always()
+      run: |
+        mkdir -p pages
+        if [ -d gh-pages ]; then rsync -a gh-pages/ pages/; fi
+        rsync -a "playwright-report-${{ github.run_id }}/" "pages/${{ github.run_id }}/"
+        touch pages/.nojekyll
 
     - name: Upload Playwright report as an artifact
       uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report
-        path: playwright-report/
+        path: "playwright-report-${{ github.run_id }}/"
         retention-days: 7
 
     - name: Setup Pages
@@ -61,7 +81,7 @@ jobs:
       if: always()
       uses: actions/upload-pages-artifact@v3
       with:
-        path: playwright-report/
+        path: pages/
 
     - name: Deploy to GitHub Pages
       if: always()


### PR DESCRIPTION
## Summary
- publish each Playwright test run to its own GitHub Pages subdirectory
- retain previous reports by merging existing `gh-pages` content

## Testing
- `npm install`
- `npx playwright install`
- `npx playwright install-deps`
- `npm run test:e2e` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c617d8cef8832e851ea0de7b6f317a