### PR TITLE
feat: add ottoneu integration

### DIFF
--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -45,7 +45,6 @@ export async function connectOttoneu(teamUrl: string) {
       .insert({
         user_id: user.id,
         provider: 'ottoneu',
-        provider_user_id: teamId,
       })
       .select()
       .single();

--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -1,0 +1,163 @@
+'use server';
+
+import { createClient } from '@/utils/supabase/server';
+
+/**
+ * Connects an Ottoneu team to the user's account using the public team URL.
+ * @param teamUrl - The Ottoneu team URL (e.g., https://ottoneu.fangraphs.com/football/309/team/2514).
+ * @returns The inserted integration or an error.
+ */
+export async function connectOttoneu(teamUrl: string) {
+  const supabase = createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in to connect your Ottoneu team.' };
+  }
+
+  const match = teamUrl.match(/ottoneu\.fangraphs\.com\/football\/(\d+)\/team\/(\d+)/);
+  if (!match) {
+    return { error: 'Invalid Ottoneu team URL.' };
+  }
+
+  const leagueId = match[1];
+  const teamId = match[2];
+
+  try {
+    const res = await fetch(teamUrl);
+    if (!res.ok) {
+      return { error: `Failed to fetch team page: ${res.statusText}` };
+    }
+    const html = await res.text();
+    const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
+    let teamName = titleMatch ? titleMatch[1] : '';
+    if (teamName.includes('-')) {
+      teamName = teamName.split('-')[0].trim();
+    } else if (teamName.includes('|')) {
+      teamName = teamName.split('|')[0].trim();
+    }
+    if (!teamName) {
+      return { error: 'Could not determine team name from page.' };
+    }
+
+    const { data: integration, error: insertError } = await supabase
+      .from('user_integrations')
+      .insert({
+        user_id: user.id,
+        provider: 'ottoneu',
+        provider_user_id: teamId,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      return { error: insertError.message };
+    }
+
+    const { error: leagueError } = await supabase
+      .from('leagues')
+      .upsert({
+        user_id: user.id,
+        user_integration_id: integration.id,
+        league_id: leagueId,
+        name: teamName,
+      }, { onConflict: 'league_id,user_integration_id' });
+    if (leagueError) {
+      return { error: leagueError.message };
+    }
+
+    const { error: teamError } = await supabase
+      .from('teams')
+      .upsert({
+        user_integration_id: integration.id,
+        team_id: teamId,
+        team_key: teamId,
+        league_id: leagueId,
+        name: teamName,
+      }, { onConflict: 'team_id,user_integration_id' });
+    if (teamError) {
+      return { error: teamError.message };
+    }
+
+    return { integration };
+  } catch (error) {
+    return { error: 'Failed to fetch Ottoneu team page.' };
+  }
+}
+
+/**
+ * Gets the Ottoneu integration for the current user.
+ */
+export async function getOttoneuIntegration() {
+  const supabase = createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in.' };
+  }
+
+  const { data, error } = await supabase
+    .from('user_integrations')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('provider', 'ottoneu')
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    return { error: error.message };
+  }
+
+  return { integration: data };
+}
+
+/**
+ * Removes an Ottoneu integration from the user's account.
+ * @param integrationId - The ID of the integration to remove.
+ */
+export async function removeOttoneuIntegration(integrationId: number) {
+  const supabase = createClient();
+
+  const { error: deleteTeamsError } = await supabase
+    .from('teams')
+    .delete()
+    .eq('user_integration_id', integrationId);
+  if (deleteTeamsError) {
+    return { error: `Failed to delete teams: ${deleteTeamsError.message}` };
+  }
+
+  const { error: deleteLeaguesError } = await supabase
+    .from('leagues')
+    .delete()
+    .eq('user_integration_id', integrationId);
+  if (deleteLeaguesError) {
+    return { error: `Failed to delete leagues: ${deleteLeaguesError.message}` };
+  }
+
+  const { error: deleteIntegrationError } = await supabase
+    .from('user_integrations')
+    .delete()
+    .eq('id', integrationId);
+  if (deleteIntegrationError) {
+    return { error: `Failed to delete integration: ${deleteIntegrationError.message}` };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Gets the teams for an Ottoneu integration from the database.
+ * @param integrationId - The ID of the integration.
+ */
+export async function getTeams(integrationId: number) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('teams')
+    .select('*')
+    .eq('user_integration_id', integrationId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { teams: data };
+}

--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -61,7 +61,7 @@ export async function connectOttoneu(teamUrl: string) {
         user_integration_id: integration.id,
         league_id: leagueId,
         name: teamName,
-      }, { onConflict: 'league_id,user_integration_id' });
+      }, { onConflict: 'league_id' });
     if (leagueError) {
       return { error: leagueError.message };
     }
@@ -74,7 +74,7 @@ export async function connectOttoneu(teamUrl: string) {
         team_key: teamId,
         league_id: leagueId,
         name: teamName,
-      }, { onConflict: 'team_id,user_integration_id' });
+      }, { onConflict: 'team_key,user_integration_id' });
     if (teamError) {
       return { error: teamError.message };
     }

--- a/src/app/integrations/ottoneu/page.tsx
+++ b/src/app/integrations/ottoneu/page.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useEffect, FormEvent } from 'react';
+import { connectOttoneu, getOttoneuIntegration, removeOttoneuIntegration, getTeams } from './actions';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+/**
+ * The page for managing the Ottoneu integration.
+ */
+export default function OttoneuPage() {
+  const [teamUrl, setTeamUrl] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [integration, setIntegration] = useState<any | null>(null);
+  const [teams, setTeams] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  useEffect(() => {
+    const checkIntegration = async () => {
+      const { integration, error } = await getOttoneuIntegration();
+      if (error) {
+        setError(error);
+      } else if (integration) {
+        setIntegration(integration);
+        const { teams } = await getTeams(integration.id);
+        if (teams) setTeams(teams);
+      }
+      setLoading(false);
+    };
+    checkIntegration();
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const { integration, error } = await connectOttoneu(teamUrl);
+    if (error) {
+      setError(error);
+      return;
+    }
+    if (integration) {
+      setIntegration(integration);
+      const { teams } = await getTeams(integration.id);
+      if (teams) setTeams(teams);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!integration) return;
+    setIsRemoving(true);
+    const { success, error } = await removeOttoneuIntegration(integration.id);
+    setIsRemoving(false);
+    if (error) {
+      setError(error);
+    } else if (success) {
+      setIntegration(null);
+      setTeams([]);
+      setTeamUrl('');
+    }
+  };
+
+  if (loading) {
+    return <p className="p-4">Loading...</p>;
+  }
+
+  return (
+    <main className="p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Ottoneu</CardTitle>
+          <CardDescription>
+            Connect your Ottoneu fantasy team by providing your public team link.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {integration ? (
+            <div className="space-y-4">
+              {teams.length > 0 && <p>Connected team: {teams[0].name}</p>}
+              <Button variant="destructive" onClick={handleRemove} disabled={isRemoving}>
+                Remove Integration
+              </Button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="teamUrl">Ottoneu Team URL</Label>
+                <Input
+                  id="teamUrl"
+                  value={teamUrl}
+                  onChange={(e) => setTeamUrl(e.target.value)}
+                  placeholder="https://ottoneu.fangraphs.com/football/309/team/2514"
+                />
+              </div>
+              {error && <p className="text-destructive">{error}</p>}
+              <Button type="submit">Connect</Button>
+            </form>
+          )}
+          {integration && error && <p className="text-destructive mt-2">{error}</p>}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -15,7 +15,7 @@ export default function IntegrationsPage() {
             Connect your fantasy football accounts to get started.
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Link href="/integrations/sleeper">
             <Card className="hover:bg-muted">
               <CardHeader>
@@ -32,6 +32,16 @@ export default function IntegrationsPage() {
                 <CardTitle>Yahoo</CardTitle>
                 <CardDescription>
                   Connect your Yahoo account to import your leagues.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+          <Link href="/integrations/ottoneu">
+            <Card className="hover:bg-muted">
+              <CardHeader>
+                <CardTitle>Ottoneu</CardTitle>
+                <CardDescription>
+                  Connect your Ottoneu team by providing a public team link.
                 </CardDescription>
               </CardHeader>
             </Card>


### PR DESCRIPTION
## Summary
- add server actions to connect and manage Ottoneu fantasy integrations
- expose Ottoneu setup page with team URL form and removal
- list Ottoneu option alongside existing integrations

## Testing
- `npm test`
- `npm run test:e2e` *(fails: createClient at main-page.spec.ts:12)*

------
https://chatgpt.com/codex/tasks/task_e_68c62391a2ac832ea1902a71e1c7ab52