### PR TITLE
feat: add ottoneu integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Roster Loom is a one-stop destination for keeping track of your various fantasy 
 ## Features
 
 - **All-in-one scoreboard:** Get at-a-glance summary of who you have playing, you you're playing against, and current matchup scores
-- **Multi-Platform Support:** Seamlessly connect and manage your teams from Sleeper and Yahoo Fantasy Football.
+- **Multi-Platform Support:** Seamlessly connect and manage your teams from Sleeper, Yahoo, and Ottoneu Fantasy Football.
 - **League-Wide Overview:** Keep track of all your leagues and teams in one place.
 
 ## Getting Started
@@ -58,7 +58,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 3.  **Integrate your fantasy football accounts:**
     - Navigate to the `/integrations` page.
-    - Connect your Sleeper and/or Yahoo Fantasy Football accounts.
+    - Connect your Sleeper, Yahoo, and/or Ottoneu Fantasy Football accounts.
 
 4.  **View your leagues and teams:**
     Once your accounts are integrated, you can view your leagues and teams on the main dashboard.

--- a/src/app/integrations/ottoneu/README.md
+++ b/src/app/integrations/ottoneu/README.md
@@ -1,0 +1,9 @@
+# Ottoneu Integration
+
+This integration allows users to link an Ottoneu fantasy football team by
+providing the public team URL. The application scrapes the team page to obtain
+the team and league names and stores the league and team identifiers for later
+use.
+
+No authentication is required; users simply paste their team link to connect.
+

--- a/src/app/integrations/ottoneu/actions.test.ts
+++ b/src/app/integrations/ottoneu/actions.test.ts
@@ -1,0 +1,34 @@
+import { getOttoneuTeamInfo } from './actions';
+
+global.fetch = jest.fn();
+
+describe('ottoneu actions', () => {
+  beforeEach(() => {
+    (fetch as jest.Mock).mockReset();
+  });
+
+  it('parses team and league info from page', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<span class="teamName">My Team</span><span class="desktop-navigation">My League</span>'
+        ),
+    });
+    const result = await getOttoneuTeamInfo(
+      'https://ottoneu.fangraphs.com/football/309/team/2514'
+    );
+    expect(result).toEqual({
+      teamName: 'My Team',
+      leagueName: 'My League',
+      leagueId: '309',
+      teamId: '2514',
+    });
+  });
+
+  it('returns error on invalid url', async () => {
+    const result = await getOttoneuTeamInfo('https://example.com');
+    expect(result).toEqual({ error: 'Invalid Ottoneu team URL.' });
+  });
+});
+

--- a/src/app/integrations/ottoneu/actions.test.ts
+++ b/src/app/integrations/ottoneu/actions.test.ts
@@ -12,7 +12,7 @@ describe('ottoneu actions', () => {
       ok: true,
       text: () =>
         Promise.resolve(
-          '<span class="teamName">My Team</span><span class="desktop-navigation">My League</span>'
+          '<span class="teamName">My Team</span><a href="/football/309/"><span class="desktop-navigation">My League</span></a>'
         ),
     });
     const result = await getOttoneuTeamInfo(

--- a/src/app/integrations/ottoneu/actions.test.ts
+++ b/src/app/integrations/ottoneu/actions.test.ts
@@ -26,6 +26,25 @@ describe('ottoneu actions', () => {
     });
   });
 
+  it('handles single quotes in markup', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          "<span class='teamName'>My Team</span><a href='/football/309/'><span class='desktop-navigation'>My League</span></a>"
+        ),
+    });
+    const result = await getOttoneuTeamInfo(
+      'https://ottoneu.fangraphs.com/football/309/team/2514'
+    );
+    expect(result).toEqual({
+      teamName: 'My Team',
+      leagueName: 'My League',
+      leagueId: '309',
+      teamId: '2514',
+    });
+  });
+
   it('returns error on invalid url', async () => {
     const result = await getOttoneuTeamInfo('https://example.com');
     expect(result).toEqual({ error: 'Invalid Ottoneu team URL.' });

--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -21,8 +21,19 @@ export async function getOttoneuTeamInfo(teamUrl: string) {
       return { error: 'Failed to fetch team page.' };
     }
     const html = await res.text();
-    const teamNameMatch = html.match(/<span class="teamName">([^<]+)<\/span>/);
-    const leagueNameMatch = html.match(/<span class="desktop-navigation">([^<]+)<\/span>/);
+    const teamNameMatch = html.match(
+      /<span class="teamName">([^<]+)<\/span>/
+    );
+    const leagueNameRegex = new RegExp(
+      `<a[^>]+href="/football/${leagueId}/"[^>]*>\\s*<span class="desktop-navigation">([^<]+)<\\/span>`,
+      'i'
+    );
+    let leagueNameMatch = html.match(leagueNameRegex);
+    if (!leagueNameMatch) {
+      leagueNameMatch = html.match(
+        /<span class="desktop-navigation">([^<]+)<\/span>/
+      );
+    }
 
     const teamName = teamNameMatch ? teamNameMatch[1].trim() : 'Unknown Team';
     const leagueName = leagueNameMatch ? leagueNameMatch[1].trim() : 'Unknown League';

--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -21,7 +21,6 @@ export async function getOttoneuTeamInfo(teamUrl: string) {
       return { error: 'Failed to fetch team page.' };
     }
     const html = await res.text();
-    console.log('Fetched Ottoneu page:', html);
     const teamNameMatch = html.match(
       /<span class=["']teamName["']>([^<]+)<\/span>/
     );
@@ -35,7 +34,6 @@ export async function getOttoneuTeamInfo(teamUrl: string) {
         /<span class=["']desktop-navigation["']>([^<]+)<\/span>/
       );
     }
-    console.log('League name match result:', leagueNameMatch);
 
     const teamName = teamNameMatch ? teamNameMatch[1].trim() : 'Unknown Team';
     const leagueName = leagueNameMatch ? leagueNameMatch[1].trim() : 'Unknown League';

--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -21,19 +21,21 @@ export async function getOttoneuTeamInfo(teamUrl: string) {
       return { error: 'Failed to fetch team page.' };
     }
     const html = await res.text();
+    console.log('Fetched Ottoneu page:', html);
     const teamNameMatch = html.match(
-      /<span class="teamName">([^<]+)<\/span>/
+      /<span class=["']teamName["']>([^<]+)<\/span>/
     );
     const leagueNameRegex = new RegExp(
-      `<a[^>]+href="/football/${leagueId}/"[^>]*>\\s*<span class="desktop-navigation">([^<]+)<\\/span>`,
+      `<a[^>]*href=["']/football/${leagueId}/["'][^>]*>\\s*<span class=["']desktop-navigation["']>([^<]+)<\\/span>`,
       'i'
     );
     let leagueNameMatch = html.match(leagueNameRegex);
     if (!leagueNameMatch) {
       leagueNameMatch = html.match(
-        /<span class="desktop-navigation">([^<]+)<\/span>/
+        /<span class=["']desktop-navigation["']>([^<]+)<\/span>/
       );
     }
+    console.log('League name match result:', leagueNameMatch);
 
     const teamName = teamNameMatch ? teamNameMatch[1].trim() : 'Unknown Team';
     const leagueName = leagueNameMatch ? leagueNameMatch[1].trim() : 'Unknown League';

--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -1,0 +1,151 @@
+'use server';
+
+import { createClient } from '@/utils/supabase/server';
+
+/**
+ * Fetches and parses an Ottoneu team page for basic info.
+ * @param teamUrl - The public Ottoneu team URL.
+ * @returns Team and league info or an error.
+ */
+export async function getOttoneuTeamInfo(teamUrl: string) {
+  const match = teamUrl.match(/football\/(\d+)\/team\/(\d+)/);
+  if (!match) {
+    return { error: 'Invalid Ottoneu team URL.' };
+  }
+
+  const [, leagueId, teamId] = match;
+
+  try {
+    const res = await fetch(teamUrl);
+    if (!res.ok) {
+      return { error: 'Failed to fetch team page.' };
+    }
+    const html = await res.text();
+    const teamNameMatch = html.match(/<span class="teamName">([^<]+)<\/span>/);
+    const leagueNameMatch = html.match(/<span class="desktop-navigation">([^<]+)<\/span>/);
+
+    const teamName = teamNameMatch ? teamNameMatch[1].trim() : 'Unknown Team';
+    const leagueName = leagueNameMatch ? leagueNameMatch[1].trim() : 'Unknown League';
+
+    return { teamName, leagueName, leagueId, teamId };
+  } catch {
+    return { error: 'Failed to fetch team page.' };
+  }
+}
+
+/**
+ * Connects an Ottoneu team to the user's account.
+ * @param teamUrl - The public team URL.
+ * @returns The parsed team info or an error.
+ */
+export async function connectOttoneu(teamUrl: string) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in to connect your Ottoneu team.' };
+  }
+
+  const info = await getOttoneuTeamInfo(teamUrl);
+  if ('error' in info) {
+    return { error: info.error };
+  }
+
+  const { teamName, leagueName, leagueId, teamId } = info;
+
+  const { data: integration, error: insertError } = await supabase
+    .from('user_integrations')
+    .insert({
+      user_id: user.id,
+      provider: 'ottoneu',
+      provider_user_id: teamId,
+    })
+    .select()
+    .single();
+
+  if (insertError) {
+    return { error: insertError.message };
+  }
+
+  const { error: leagueError } = await supabase.from('leagues').upsert({
+    league_id: leagueId,
+    name: leagueName,
+    user_integration_id: integration.id,
+  });
+
+  if (leagueError) {
+    return { error: leagueError.message };
+  }
+
+  return { teamName, leagueName };
+}
+
+/**
+ * Removes an Ottoneu integration.
+ * @param integrationId - The ID of the integration to remove.
+ */
+export async function removeOttoneuIntegration(integrationId: number) {
+  const supabase = createClient();
+
+  const { error: deleteLeaguesError } = await supabase
+    .from('leagues')
+    .delete()
+    .eq('user_integration_id', integrationId);
+
+  if (deleteLeaguesError) {
+    return { error: `Failed to delete leagues: ${deleteLeaguesError.message}` };
+  }
+
+  const { error: deleteIntegrationError } = await supabase
+    .from('user_integrations')
+    .delete()
+    .eq('id', integrationId);
+
+  if (deleteIntegrationError) {
+    return { error: `Failed to delete integration: ${deleteIntegrationError.message}` };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Gets the Ottoneu integration for the current user.
+ */
+export async function getOttoneuIntegration() {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in.' };
+  }
+
+  const { data, error } = await supabase
+    .from('user_integrations')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('provider', 'ottoneu')
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    return { error: error.message };
+  }
+
+  return { integration: data };
+}
+
+/**
+ * Gets leagues linked to an integration.
+ * @param integrationId - The integration ID.
+ */
+export async function getLeagues(integrationId: number) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('leagues')
+    .select('*')
+    .eq('user_integration_id', integrationId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { leagues: data };
+}
+

--- a/src/app/integrations/ottoneu/page.tsx
+++ b/src/app/integrations/ottoneu/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useState, FormEvent } from 'react';
+import {
+  connectOttoneu,
+  getOttoneuIntegration,
+  removeOttoneuIntegration,
+  getLeagues,
+  getOttoneuTeamInfo,
+} from './actions';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+/**
+ * Page for managing the Ottoneu integration.
+ */
+export default function OttoneuPage() {
+  const [teamUrl, setTeamUrl] = useState('');
+  const [integration, setIntegration] = useState<any | null>(null);
+  const [teamName, setTeamName] = useState('');
+  const [leagueName, setLeagueName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  useEffect(() => {
+    const init = async () => {
+      const { integration, error } = await getOttoneuIntegration();
+      if (error) {
+        setError(error);
+        return;
+      }
+      if (integration) {
+        setIntegration(integration);
+        const { leagues } = await getLeagues(integration.id);
+        if (leagues && leagues[0]) {
+          setLeagueName(leagues[0].name);
+          const info = await getOttoneuTeamInfo(`https://ottoneu.fangraphs.com/football/${leagues[0].league_id}/team/${integration.provider_user_id}`);
+          if ('teamName' in info) {
+            setTeamName(info.teamName);
+          }
+        }
+      }
+    };
+    init();
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const { teamName, leagueName, error } = await connectOttoneu(teamUrl);
+    if (error) {
+      setError(error);
+      return;
+    }
+    setTeamName(teamName);
+    setLeagueName(leagueName);
+    const { integration } = await getOttoneuIntegration();
+    setIntegration(integration);
+  };
+
+  const handleRemove = async () => {
+    if (!integration) return;
+    setIsRemoving(true);
+    setError(null);
+    const { error } = await removeOttoneuIntegration(integration.id);
+    if (error) {
+      setError(error);
+    } else {
+      setIntegration(null);
+      setTeamUrl('');
+      setTeamName('');
+      setLeagueName('');
+    }
+    setIsRemoving(false);
+  };
+
+  return (
+    <main className="p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Ottoneu</CardTitle>
+          <CardDescription>
+            {integration
+              ? `Connected to ${teamName || 'your team'} in ${leagueName || 'your league'}`
+              : 'Enter your public team URL to connect.'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!integration ? (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <Label htmlFor="team-url">Team URL</Label>
+                <Input
+                  id="team-url"
+                  type="url"
+                  value={teamUrl}
+                  onChange={(e) => setTeamUrl(e.target.value)}
+                  required
+                />
+              </div>
+              <Button type="submit">Connect</Button>
+            </form>
+          ) : (
+            <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
+              {isRemoving ? 'Removing...' : 'Remove Integration'}
+            </Button>
+          )}
+          {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -36,6 +36,16 @@ export default function IntegrationsPage() {
               </CardHeader>
             </Card>
           </Link>
+          <Link href="/integrations/ottoneu">
+            <Card className="hover:bg-muted">
+              <CardHeader>
+                <CardTitle>Ottoneu</CardTitle>
+                <CardDescription>
+                  Connect by providing your public team URL.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
         </CardContent>
       </Card>
     </main>

--- a/src/components/integration-status.test.tsx
+++ b/src/components/integration-status.test.tsx
@@ -24,6 +24,7 @@ describe('IntegrationStatus', () => {
     expect(screen.getByText('ESPN')).toBeInTheDocument()
     expect(screen.getByText('Yahoo Sports')).toBeInTheDocument()
     expect(screen.getByText('Sleeper')).toBeInTheDocument()
+    expect(screen.getByText('Ottoneu')).toBeInTheDocument()
     expect(screen.getByText('Alert Log')).toBeInTheDocument()
     expect(screen.getByText('Successfully synced with ESPN.')).toBeInTheDocument()
     expect(screen.getByText('Live scoring data is now active.')).toBeInTheDocument()

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -7,6 +7,7 @@ export const mockIntegrations: Integration[] = [
     { id: 'espn', name: 'ESPN', status: 'ok', lastUpdated: '2 minutes ago' },
     { id: 'yahoo', name: 'Yahoo Sports', status: 'ok', lastUpdated: '3 minutes ago' },
     { id: 'sleeper', name: 'Sleeper', status: 'error', lastUpdated: '1 hour ago' },
+    { id: 'ottoneu', name: 'Ottoneu', status: 'ok', lastUpdated: '5 minutes ago' },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- add Ottoneu fantasy integration based on a public team URL
- render new Ottoneu card on integrations page and mock integration list
- document and test Ottoneu setup workflow

## Testing
- `npm test`
- `npx playwright install`
- `npx playwright install-deps` *(failed: Failed to fetch repository index, but packages already installed)*
- `npm run test:e2e` *(failed: fetch failed due to ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c629e56d30832eb5a697564e0705b8