### PR TITLE
feat: log yahoo player scores response

### DIFF
--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -609,6 +609,7 @@ export async function getYahooPlayerScores(integrationId: number, teamKey: strin
       logger.error({ error }, 'Yahoo API Error');
       return { error: `Failed to fetch player scores from Yahoo: ${error}` };
     }
+    logger.debug({ data }, 'Yahoo API response for player scores');
     const rosterData = data.fantasy_content?.team?.[1]?.roster?.['0']?.players;
 
     if (!rosterData) {


### PR DESCRIPTION
## Summary
- log raw Yahoo player score response at debug level

## Testing
- `npm test`
- `npm run test:e2e` *(fails: createClient at e2e/main-page.spec.ts:12)*

------
https://chatgpt.com/codex/tasks/task_e_68c62b57fc38832eb3c79bb8855d6f18