### PR TITLE
chore: log Yahoo player scores response

### DIFF
--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -609,6 +609,7 @@ export async function getYahooPlayerScores(integrationId: number, teamKey: strin
       logger.error({ error }, 'Yahoo API Error');
       return { error: `Failed to fetch player scores from Yahoo: ${error}` };
     }
+    logger.info({ data }, 'Yahoo player scores API response');
     const rosterData = data.fantasy_content?.team?.[1]?.roster?.['0']?.players;
 
     if (!rosterData) {


### PR DESCRIPTION
## Summary
- log Yahoo player scores API responses at info level for documentation

## Testing
- `npm test`
- `npx playwright install`
- `npx playwright install-deps`
- `npm run test:e2e` *(fails: require() of ES module uuid in e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c6330521f4832eabe0261100a57e79