### PR TITLE
feat(ottoneu): show weekly matchup if available

### DIFF
--- a/src/app/integrations/ottoneu/actions.test.ts
+++ b/src/app/integrations/ottoneu/actions.test.ts
@@ -45,6 +45,31 @@ describe('ottoneu actions', () => {
     });
   });
 
+  it('parses weekly matchup if present', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<span class="teamName">My Team</span><a href="/football/309/"><span class="desktop-navigation">My League</span></a><div class="page-header__section"><h4>Week 2 Matchup</h4><br><ul class="other-games"><li id="game-1"><div class="game-status">LIVE</div><div><a href="/football/309/game/1"><div class="other-game-home-team">My Team<span class="other-game-score home-score">13.90</span></div><div class="other-game-away-team">Opponent<span class="other-game-score away-score">0.00</span></div></a></div></li></ul></div>'
+        ),
+    });
+    const result = await getOttoneuTeamInfo(
+      'https://ottoneu.fangraphs.com/football/309/team/2514'
+    );
+    expect(result).toEqual({
+      teamName: 'My Team',
+      leagueName: 'My League',
+      leagueId: '309',
+      teamId: '2514',
+      matchup: {
+        week: 2,
+        opponentName: 'Opponent',
+        teamScore: 13.9,
+        opponentScore: 0,
+      },
+    });
+  });
+
   it('returns error on invalid url', async () => {
     const result = await getOttoneuTeamInfo('https://example.com');
     expect(result).toEqual({ error: 'Invalid Ottoneu team URL.' });

--- a/src/app/integrations/ottoneu/page.tsx
+++ b/src/app/integrations/ottoneu/page.tsx
@@ -21,6 +21,7 @@ export default function OttoneuPage() {
   const [integration, setIntegration] = useState<any | null>(null);
   const [teamName, setTeamName] = useState('');
   const [leagueName, setLeagueName] = useState('');
+  const [matchup, setMatchup] = useState<any | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isRemoving, setIsRemoving] = useState(false);
 
@@ -40,6 +41,9 @@ export default function OttoneuPage() {
           if ('teamName' in info) {
             setTeamName(info.teamName);
           }
+          if ('matchup' in info) {
+            setMatchup(info.matchup);
+          }
         }
       }
     };
@@ -56,6 +60,10 @@ export default function OttoneuPage() {
     }
     setTeamName(teamName);
     setLeagueName(leagueName);
+    const info = await getOttoneuTeamInfo(teamUrl);
+    if ('matchup' in info) {
+      setMatchup(info.matchup);
+    }
     const { integration } = await getOttoneuIntegration();
     setIntegration(integration);
   };
@@ -72,6 +80,7 @@ export default function OttoneuPage() {
       setTeamUrl('');
       setTeamName('');
       setLeagueName('');
+      setMatchup(null);
     }
     setIsRemoving(false);
   };
@@ -106,6 +115,12 @@ export default function OttoneuPage() {
             <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
               {isRemoving ? 'Removing...' : 'Remove Integration'}
             </Button>
+          )}
+          {matchup && (
+            <div className="mt-4 text-sm">
+              <p>Week {matchup.week} vs {matchup.opponentName}</p>
+              <p className="font-semibold">{matchup.teamScore.toFixed(2)} - {matchup.opponentScore.toFixed(2)}</p>
+            </div>
           )}
           {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
         </CardContent>


### PR DESCRIPTION
## Summary
- parse weekly matchup from Ottoneu team pages
- surface current matchup on Ottoneu integration page
- test matchup parsing logic

## Testing
- `npm test`
- `npm run test:e2e` *(fails: ENETUNREACH when contacting Supabase)*

------
https://chatgpt.com/codex/tasks/task_e_68c6344e746c832e8cef45897277a00e