### PR TITLE
feat: log Sleeper player score responses

### DIFF
--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -32,6 +32,8 @@ jest.mock('@/app/integrations/ottoneu/actions', () => ({
   getOttoneuTeamInfo: jest.fn(),
 }));
 
+jest.mock('@/utils/logger', () => ({ info: jest.fn(), error: jest.fn(), debug: jest.fn() }));
+
 global.fetch = jest.fn();
 
 describe('actions', () => {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -56,7 +56,7 @@ export async function buildSleeperTeams(
       `https://api.sleeper.app/v1/league/${league.league_id}/matchups/${week}`
     );
     const matchups = await matchupsResponse.json();
-    logger.debug(
+    logger.info(
       { matchups },
       'Sleeper API response for player scores'
     );

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -15,6 +15,7 @@ import {
 } from '@/app/integrations/ottoneu/actions';
 import { Team, Player } from '@/lib/types';
 import { findBestMatch } from 'string-similarity';
+import logger from '@/utils/logger';
 
 /**
  * Gets the current NFL week from the Sleeper API.
@@ -55,6 +56,10 @@ export async function buildSleeperTeams(
       `https://api.sleeper.app/v1/league/${league.league_id}/matchups/${week}`
     );
     const matchups = await matchupsResponse.json();
+    logger.debug(
+      { matchups },
+      'Sleeper API response for player scores'
+    );
 
     const userRoster = rosters.find(
       (roster: any) => roster.owner_id === integration.provider_user_id

--- a/src/app/integrations/sleeper/actions.test.ts
+++ b/src/app/integrations/sleeper/actions.test.ts
@@ -2,6 +2,7 @@ import { getMatchups } from './actions';
 import { fetchJson } from '@/lib/fetch-json';
 
 jest.mock('@/lib/fetch-json', () => ({ fetchJson: jest.fn() }));
+jest.mock('@/utils/logger', () => ({ info: jest.fn(), error: jest.fn(), debug: jest.fn() }));
 
 describe('sleeper actions', () => {
   beforeEach(() => {

--- a/src/app/integrations/sleeper/actions.ts
+++ b/src/app/integrations/sleeper/actions.ts
@@ -3,6 +3,7 @@
 import { cookies } from 'next/headers';
 import { createClient } from '@/utils/supabase/server';
 import { fetchJson } from '@/lib/fetch-json';
+import logger from '@/utils/logger';
 
 /**
  * Connects a Sleeper account to the user's account.
@@ -165,12 +166,16 @@ export async function getSleeperLeagues(userId: string, integrationId: number) {
  */
 export async function getMatchups(leagueId: string, week: string) {
   try {
-    const { data: matchups, error } = await fetchJson<any[]>(`https://api.sleeper.app/v1/league/${leagueId}/matchups/${week}`);
+    const url = `https://api.sleeper.app/v1/league/${leagueId}/matchups/${week}`;
+    const { data: matchups, error } = await fetchJson<any[]>(url);
     if (error) {
+      logger.error({ error }, 'Sleeper API error fetching player scores');
       return { error };
     }
+    logger.debug({ matchups }, 'Sleeper API response for player scores');
     return { matchups };
   } catch (error) {
+    logger.error({ error }, 'An unexpected error occurred while fetching player scores from Sleeper');
     return { error: 'An unexpected error occurred' };
   }
 }


### PR DESCRIPTION
## Summary
- add debug logging for Sleeper player score responses when building teams
- trace Sleeper matchup requests for easier debugging

## Testing
- `npm test`
- `npm run test:e2e` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c63dac7134832e930981dd98d04e3e