### PR TITLE
Fix Sleeper player score parsing

### DIFF
--- a/e2e/mocks/external-apis.js
+++ b/e2e/mocks/external-apis.js
@@ -33,8 +33,8 @@ global.fetch = async (input, init) => {
 
   if (url === 'https://api.sleeper.app/v1/league/league1/matchups/1') {
     return jsonResponse([
-      { roster_id: 1, matchup_id: 1, players_points: { p1: 10 } },
-      { roster_id: 2, matchup_id: 1, players_points: { p2: 8 } },
+      { roster_id: 1, matchup_id: 1, players_points: { p1: 10 }, players: ['p1'] },
+      { roster_id: 2, matchup_id: 1, players_points: { p2: 8 }, players: ['p2'] },
     ]);
   }
 

--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -75,8 +75,20 @@ describe('actions', () => {
       { owner_id: 'sleeper-user-2', roster_id: 2, players: ['2'], starters: ['2'] },
     ];
     const mockMatchups = [
-      { roster_id: 1, matchup_id: 1, points: 100, players_points: { '1': 20 } },
-      { roster_id: 2, matchup_id: 1, points: 90, players_points: { '2': 15 } },
+      {
+        roster_id: 1,
+        matchup_id: 1,
+        points: 100,
+        players_points: { '1': 20 },
+        players: ['1'],
+      },
+      {
+        roster_id: 2,
+        matchup_id: 1,
+        points: 90,
+        players_points: { '2': 15 },
+        players: ['2'],
+      },
     ];
     const mockLeagueUsers = [
       { user_id: 'sleeper-user-1', display_name: 'User A', metadata: { team_name: 'Team A' } },
@@ -212,8 +224,20 @@ describe('actions', () => {
     ];
 
     const mockMatchups = [
-      { roster_id: 1, matchup_id: 1, points: 100, players_points: { '1': 20 } },
-      { roster_id: 2, matchup_id: 1, points: 90, players_points: { '2': 15 } },
+      {
+        roster_id: 1,
+        matchup_id: 1,
+        points: 100,
+        players_points: { '1': 20 },
+        players: ['1'],
+      },
+      {
+        roster_id: 2,
+        matchup_id: 1,
+        points: 90,
+        players_points: { '2': 15 },
+        players: ['2'],
+      },
     ];
 
     const mockLeagueUsers = [

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -98,12 +98,9 @@ export async function buildSleeperTeams(
       opponentUser?.display_name ||
       'Opponent';
 
-    const userPlayers = userRoster.players.map((playerId: string) => {
+    const userPlayers = userMatchup.players.map((playerId: string) => {
       const player = playersData[playerId];
-      const score =
-        userMatchup.players_points && userMatchup.players_points[playerId]
-          ? userMatchup.players_points[playerId]
-          : 0;
+      const score = userMatchup.players_points?.[playerId] ?? 0;
       return {
         id: playerId,
         name: player.full_name,
@@ -119,30 +116,27 @@ export async function buildSleeperTeams(
       };
     });
 
-    const opponentPlayers = opponentRoster
-      ? opponentRoster.players.map((playerId: string) => {
-          const player = playersData[playerId];
-          const score =
-            opponentMatchup.players_points &&
-            opponentMatchup.players_points[playerId]
-              ? opponentMatchup.players_points[playerId]
-              : 0;
+    const opponentPlayers =
+      opponentMatchup && opponentMatchup.players
+        ? opponentMatchup.players.map((playerId: string) => {
+            const player = playersData[playerId];
+            const score = opponentMatchup.players_points?.[playerId] ?? 0;
 
-          return {
-            id: playerId,
-            name: player.full_name,
-            position: player.position,
-            realTeam: player.team,
-            score: score,
-            gameStatus: 'pregame',
-            onUserTeams: 0,
-            onOpponentTeams: 0,
-            gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
-            imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
-            on_bench: !opponentRoster.starters.includes(playerId),
-          };
-        })
-      : [];
+            return {
+              id: playerId,
+              name: player.full_name,
+              position: player.position,
+              realTeam: player.team,
+              score: score,
+              gameStatus: 'pregame',
+              onUserTeams: 0,
+              onOpponentTeams: 0,
+              gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
+              imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
+              on_bench: !opponentRoster.starters.includes(playerId),
+            };
+          })
+        : [];
 
     teams.push({
       id: league.id,

--- a/src/app/integrations/sleeper/actions.ts
+++ b/src/app/integrations/sleeper/actions.ts
@@ -266,7 +266,7 @@ export async function getLeagueMatchups(leagueId: string, week: string) {
           last_name: playerDetails?.last_name || 'Player',
           position: playerDetails?.position || 'N/A',
           team: playerDetails?.team || 'N/A',
-          score: matchup.players_points[playerId] || 0,
+          score: matchup.players_points?.[playerId] ?? 0,
         };
       });
 


### PR DESCRIPTION
## Summary
- Iterate over matchup player IDs when building Sleeper teams
- Safely read player scores from `players_points` map
- Update tests and mocks for new Sleeper parsing logic

## Testing
- `npm test`
- `npm run test:e2e` *(fails: ENETUNREACH fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c640e65628832eb7d2e24cb5673faa