### PR TITLE
feat: hide pregame chip on player cards

### DIFF
--- a/src/components/player-card.test.tsx
+++ b/src/components/player-card.test.tsx
@@ -36,4 +36,10 @@ describe('PlayerCard', () => {
     expect(screen.getByText('10.5')).toBeInTheDocument()
     expect(screen.getByText('Possession')).toBeInTheDocument()
   })
+
+  it('does not render a chip for pregame status', () => {
+    const pregamePlayer: Player = { ...player, gameStatus: 'pregame' }
+    render(<PlayerCard player={pregamePlayer} />)
+    expect(screen.queryByText('Pregame')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/player-card.tsx
+++ b/src/components/player-card.tsx
@@ -13,7 +13,6 @@ const gameStatusConfig = {
     possession: { text: 'Possession', className: 'bg-primary/20 text-primary-foreground border-primary' },
     sidelines: { text: 'Sidelines', className: 'bg-secondary' },
     final: { text: 'Final', className: 'bg-muted text-muted-foreground' },
-    pregame: { text: 'Pregame', className: 'bg-accent/20 text-accent-foreground border-accent' },
 };
 
 /**
@@ -89,9 +88,11 @@ export function PlayerCard({ player }: { player: Player & { count?: number } }) 
                     )}>
                         {currentScore.toFixed(1)}
                     </p>
-                    <Badge variant="outline" className={cn("capitalize text-xs h-5 mt-0.5", statusInfo.className)}>
-                        {statusInfo.text}
-                    </Badge>
+                    {statusInfo && (
+                        <Badge variant="outline" className={cn("capitalize text-xs h-5 mt-0.5", statusInfo.className)}>
+                            {statusInfo.text}
+                        </Badge>
+                    )}
                 </div>
             </Card>
         </TooltipProvider>


### PR DESCRIPTION
## Summary
- stop rendering a badge for players in a pregame state
- cover pregame rendering in PlayerCard tests

## Testing
- `npm test`
- `npm run test:e2e` (fails: fetch failed ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_68c647bbc7b8832ea35b683dc7761430