### PR TITLE
feat: add typed Sleeper interfaces

### DIFF
--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -1,4 +1,5 @@
 import { getTeams, buildSleeperTeams, buildYahooTeams } from './actions';
+import { SleeperRoster, SleeperMatchup, SleeperUser, SleeperPlayer } from '@/lib/types';
 import { createClient } from '@/utils/supabase/server';
 import { getLeagues } from '@/app/integrations/sleeper/actions';
 import {
@@ -67,15 +68,15 @@ describe('actions', () => {
   });
 
   describe('buildSleeperTeams', () => {
-    const mockPlayersData = {
+    const mockPlayersData: Record<string, SleeperPlayer> = {
       '1': { full_name: 'Player One', position: 'QB', team: 'TEAMA' },
       '2': { full_name: 'Player Two', position: 'WR', team: 'TEAMB' },
     };
-    const mockRosters = [
+    const mockRosters: SleeperRoster[] = [
       { owner_id: 'sleeper-user-1', roster_id: 1, players: ['1'], starters: ['1'] },
       { owner_id: 'sleeper-user-2', roster_id: 2, players: ['2'], starters: ['2'] },
     ];
-    const mockMatchups = [
+    const mockMatchups: SleeperMatchup[] = [
       {
         roster_id: 1,
         matchup_id: 1,
@@ -91,7 +92,7 @@ describe('actions', () => {
         players: ['2'],
       },
     ];
-    const mockLeagueUsers = [
+    const mockLeagueUsers: SleeperUser[] = [
       { user_id: 'sleeper-user-1', display_name: 'User A', metadata: { team_name: 'Team A' } },
       { user_id: 'sleeper-user-2', display_name: 'User B', metadata: { team_name: 'Team B' } },
     ];
@@ -99,7 +100,7 @@ describe('actions', () => {
     it('returns empty array when getLeagues fails', async () => {
       (getLeagues as jest.Mock).mockResolvedValue({ leagues: null, error: 'err' });
       const result = await buildSleeperTeams(
-        { id: 'int-1', provider_user_id: 'sleeper-user-1' },
+        { id: 1, provider_user_id: 'sleeper-user-1' },
         1,
         mockPlayersData
       );
@@ -108,7 +109,7 @@ describe('actions', () => {
 
     it('builds sleeper teams correctly', async () => {
       (getLeagues as jest.Mock).mockResolvedValue({
-        leagues: [{ id: 'league-1', league_id: 'sleeper-league-1' }],
+        leagues: [{ id: 1, league_id: 'sleeper-league-1' }],
         error: null,
       });
 
@@ -118,7 +119,7 @@ describe('actions', () => {
         .mockResolvedValueOnce({ json: () => Promise.resolve(mockLeagueUsers) });
 
       const result = await buildSleeperTeams(
-        { id: 'int-1', provider_user_id: 'sleeper-user-1' },
+        { id: 1, provider_user_id: 'sleeper-user-1' },
         1,
         mockPlayersData
       );

--- a/src/app/integrations/sleeper/page.tsx
+++ b/src/app/integrations/sleeper/page.tsx
@@ -16,6 +16,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import Image from 'next/image';
+import { SleeperLeague, SleeperEnrichedMatchup, SleeperMatchupPlayer } from '@/lib/types';
 
 /**
  * The page for managing the Sleeper integration.
@@ -24,13 +25,13 @@ import Image from 'next/image';
 export default function SleeperPage() {
   const [username, setUsername] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [leagues, setLeagues] = useState<any[]>([]);
+  const [leagues, setLeagues] = useState<SleeperLeague[]>([]);
   const [integration, setIntegration] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
   const [isRemoving, setIsRemoving] = useState(false);
-  const [selectedLeague, setSelectedLeague] = useState<any | null>(null);
+  const [selectedLeague, setSelectedLeague] = useState<SleeperLeague | null>(null);
   const [selectedWeek, setSelectedWeek] = useState('1');
-  const [matchups, setMatchups] = useState<any[]>([]);
+  const [matchups, setMatchups] = useState<SleeperEnrichedMatchup[]>([]);
   const [loadingMatchups, setLoadingMatchups] = useState(false);
 
   useEffect(() => {
@@ -128,7 +129,7 @@ export default function SleeperPage() {
     return <main className="p-4">Loading...</main>;
   }
 
-  const groupedMatchups = matchups.reduce((acc, matchup) => {
+  const groupedMatchups = matchups.reduce<Record<number, SleeperEnrichedMatchup[]>>((acc, matchup) => {
     const matchupId = matchup.matchup_id;
     if (!acc[matchupId]) {
       acc[matchupId] = [];
@@ -220,9 +221,9 @@ export default function SleeperPage() {
               <p>Loading matchups...</p>
             ) : (
               <div className="space-y-4">
-                {Object.values(groupedMatchups).map((matchupPair: any, index: number) => (
+                {Object.values(groupedMatchups).map((matchupPair, index) => (
                   <div key={index} className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    {matchupPair.map((team: any) => (
+                    {matchupPair.map((team) => (
                       <Card key={team.roster_id}>
                         <CardHeader className="flex flex-row items-center justify-between">
                           <div className="flex items-center space-x-2">
@@ -248,7 +249,7 @@ export default function SleeperPage() {
                               </TableRow>
                             </TableHeader>
                             <TableBody>
-                              {team.players.map((player: any) => (
+                              {team.players.map((player: SleeperMatchupPlayer) => (
                                 <TableRow key={player.player_id}>
                                   <TableCell>{player.first_name} {player.last_name}</TableCell>
                                   <TableCell>{player.position}</TableCell>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -373,7 +373,7 @@ function getPayloadConfigFromPayload(
     key in payload &&
     typeof payload[key as keyof typeof payload] === "string"
   ) {
-    configLabelKey = payload[key as key of typeof payload] as string
+    configLabelKey = payload[key as keyof typeof payload] as string
   } else if (
     payloadPayload &&
     key in payloadPayload &&

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,3 +91,98 @@ export type Team = {
     players: Player[];
   };
 };
+
+/**
+ * Represents a Sleeper league.
+ */
+export interface SleeperLeague {
+  /** Internal database identifier. */
+  id?: number;
+  /** Sleeper league identifier. */
+  league_id: string;
+  /** Display name of the league. */
+  name?: string;
+  /** Season year of the league. */
+  season?: string;
+  /** Number of rosters in the league. */
+  total_rosters?: number;
+  /** Current status of the league. */
+  status?: string;
+}
+
+/**
+ * Represents a Sleeper roster.
+ */
+export interface SleeperRoster {
+  /** Unique roster identifier. */
+  roster_id: number;
+  /** User identifier for the roster owner. */
+  owner_id: string;
+  /** Player IDs on the roster. */
+  players: string[];
+  /** Starter player IDs. */
+  starters: string[];
+}
+
+/**
+ * Represents a Sleeper matchup.
+ */
+export interface SleeperMatchup {
+  /** Roster participating in the matchup. */
+  roster_id: number;
+  /** Matchup grouping identifier. */
+  matchup_id: number;
+  /** Fantasy points scored by the roster. */
+  points: number;
+  /** Player IDs involved in the matchup. */
+  players: string[];
+  /** Points scored by each player. */
+  players_points?: Record<string, number>;
+}
+
+/**
+ * Represents a Sleeper user within a league.
+ */
+export interface SleeperUser {
+  user_id: string;
+  display_name: string;
+  avatar?: string;
+  metadata?: {
+    team_name?: string;
+  };
+}
+
+/**
+ * Represents details for an NFL player from Sleeper.
+ */
+export interface SleeperPlayer {
+  full_name?: string;
+  first_name?: string;
+  last_name?: string;
+  position?: string;
+  team?: string;
+}
+
+/**
+ * Represents a player within a Sleeper matchup.
+ */
+export interface SleeperMatchupPlayer {
+  player_id: string;
+  first_name: string;
+  last_name: string;
+  position: string;
+  team: string;
+  score: number;
+}
+
+/**
+ * Represents a Sleeper matchup enriched with user and player information.
+ */
+export interface SleeperEnrichedMatchup extends SleeperMatchup {
+  user: {
+    display_name: string;
+    avatar?: string;
+  };
+  players: SleeperMatchupPlayer[];
+  total_points: number;
+}


### PR DESCRIPTION
## Summary
- define interfaces for Sleeper league, roster, matchup, user, and player data
- use new types across Sleeper actions and pages
- tighten tests with typed Sleeper mocks

## Testing
- `npm test`
- `npm run typecheck` *(fails: src/app/integrations/yahoo/actions.test.ts(108,12): error TS18048: 'result.players' is possibly 'undefined'. src/components/player-card.test.tsx(7,5): error TS2322: Type 'number' is not assignable to type 'string'. src/lib/mock-data.ts...)*


------
https://chatgpt.com/codex/tasks/task_e_68c6fc416118832eb48ca24c684ef4b4