### PR TITLE
Parallelize team integration fetches

### DIFF
--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -1,4 +1,5 @@
-import { getTeams, buildSleeperTeams, buildYahooTeams, teamBuilders } from './actions';
+import * as actions from './actions';
+const { getTeams, buildSleeperTeams, buildYahooTeams } = actions;
 import { SleeperRoster, SleeperMatchup, SleeperUser, SleeperPlayer } from '@/lib/types';
 import { createClient } from '@/utils/supabase/server';
 import { getLeagues } from '@/app/integrations/sleeper/actions';
@@ -640,18 +641,20 @@ describe('actions', () => {
         .mockResolvedValueOnce({ json: () => Promise.resolve({ week: 1 }) })
         .mockResolvedValueOnce({ json: () => Promise.resolve({}) });
 
+      const builders = await actions.getTeamBuilders();
+
       const sleeperSpy = jest
-        .spyOn(teamBuilders, 'buildSleeperTeams')
+        .spyOn(builders, 'buildSleeperTeams')
         .mockImplementation(
           () => new Promise((resolve) => setTimeout(() => resolve([]), 50))
         );
       const yahooSpy = jest
-        .spyOn(teamBuilders, 'buildYahooTeams')
+        .spyOn(builders, 'buildYahooTeams')
         .mockImplementation(
           () => new Promise((resolve) => setTimeout(() => resolve([]), 50))
         );
       const ottoneuSpy = jest
-        .spyOn(teamBuilders, 'buildOttoneuTeams')
+        .spyOn(builders, 'buildOttoneuTeams')
         .mockImplementation(
           () => new Promise((resolve) => setTimeout(() => resolve([]), 50))
         );
@@ -684,13 +687,15 @@ describe('actions', () => {
         .mockResolvedValueOnce({ json: () => Promise.resolve({ week: 1 }) })
         .mockResolvedValueOnce({ json: () => Promise.resolve({}) });
 
+      const builders = await actions.getTeamBuilders();
+
       const sleeperSpy = jest
-        .spyOn(teamBuilders, 'buildSleeperTeams')
+        .spyOn(builders, 'buildSleeperTeams')
         .mockResolvedValue([
           { id: 1, name: 'S', totalScore: 0, players: [], opponent: { name: '', totalScore: 0, players: [] } } as any,
         ]);
       const yahooSpy = jest
-        .spyOn(teamBuilders, 'buildYahooTeams')
+        .spyOn(builders, 'buildYahooTeams')
         .mockRejectedValue(new Error('fail'));
 
       const result = await getTeams();

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -414,11 +414,15 @@ export async function buildOttoneuTeams(integration: any): Promise<Team[]> {
   ];
 }
 
-export const teamBuilders = {
+const teamBuilders = {
   buildSleeperTeams,
   buildYahooTeams,
   buildOttoneuTeams,
 };
+
+export async function getTeamBuilders() {
+  return teamBuilders;
+}
 
 /**
  * Gets the user's teams from all integrated platforms.
@@ -455,11 +459,11 @@ export async function getTeams() {
 
   const integrationPromises = integrations.map((integration) => {
     if (integration.provider === 'sleeper') {
-      return teamBuilders['buildSleeperTeams'](integration, week, playersData);
+      return teamBuilders.buildSleeperTeams(integration, week, playersData);
     } else if (integration.provider === 'yahoo') {
-      return teamBuilders['buildYahooTeams'](integration, playerNameMap);
+      return teamBuilders.buildYahooTeams(integration, playerNameMap);
     } else if (integration.provider === 'ottoneu') {
-      return teamBuilders['buildOttoneuTeams'](integration);
+      return teamBuilders.buildOttoneuTeams(integration);
     }
     return Promise.resolve([]);
   });


### PR DESCRIPTION
## Summary
- run Sleeper, Yahoo, and Ottoneu fetches concurrently via `Promise.all`
- centralize team builders in `teamBuilders` for easier mocking
- add tests for parallel execution and provider error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ff51b3e8832e8c3a4d5a80b74a3b