### PR TITLE
feat: add live score updates to player cards

### DIFF
--- a/src/components/player-card.test.tsx
+++ b/src/components/player-card.test.tsx
@@ -4,7 +4,7 @@ import type { Player } from '@/lib/types'
 
 describe('PlayerCard', () => {
   const player: Player = {
-    id: 1,
+    id: '1',
     name: 'Test Player',
     position: 'QB',
     realTeam: 'TB',
@@ -26,5 +26,15 @@ describe('PlayerCard', () => {
     expect(screen.getByText('QB - TB')).toBeInTheDocument()
     expect(screen.getByText('10.5')).toBeInTheDocument()
     expect(screen.queryByText('Possession')).not.toBeInTheDocument()
+  })
+
+  it('updates when liveScore changes', async () => {
+    const { rerender } = render(<PlayerCard player={player} liveScore={10.5} />)
+
+    expect(screen.getByText('10.5')).toBeInTheDocument()
+
+    rerender(<PlayerCard player={player} liveScore={20.1} />)
+
+    expect(await screen.findByText('20.1')).toBeInTheDocument()
   })
 })

--- a/src/components/player-card.tsx
+++ b/src/components/player-card.tsx
@@ -6,13 +6,20 @@ import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { User, Users } from "lucide-react";
 import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { useLivePlayerScore } from "@/hooks/use-live-player-score";
 
 /**
  * A card that displays information about a player.
  * @param player - The player to display.
  * @returns A card that displays information about a player.
  */
-export function PlayerCard({ player }: { player: Player & { count?: number } }) {
+export function PlayerCard({ player, liveScore }: { player: Player & { count?: number }; liveScore?: number }) {
+    const score = useLivePlayerScore(
+        player.id,
+        liveScore ?? player.score,
+        liveScore !== undefined ? async () => liveScore : undefined
+    );
+
     return (
         <TooltipProvider>
             <Card className="flex items-center p-2 shadow-sm hover:shadow-primary/10 transition-shadow duration-300 text-sm">
@@ -54,9 +61,9 @@ export function PlayerCard({ player }: { player: Player & { count?: number } }) 
                         </Tooltip>
                     )}
                 </div>
-                 <div className="text-right">
+                <div className="text-right">
                     <p className="text-xl font-bold text-foreground">
-                        {player.score.toFixed(1)}
+                        {score.toFixed(1)}
                     </p>
                 </div>
             </Card>

--- a/src/hooks/use-live-player-score.ts
+++ b/src/hooks/use-live-player-score.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Polls the backend for a player's live score.
+ * @param playerId - Identifier for the player.
+ * @param initialScore - Starting score before live updates arrive.
+ * @param fetchScore - Optional fetcher to retrieve a player's score. Defaults to calling `/api/players/${playerId}/score`.
+ * @returns The latest known score for the player.
+ */
+export function useLivePlayerScore(
+  playerId: string,
+  initialScore: number,
+  fetchScore?: (id: string) => Promise<number>
+): number {
+  const [score, setScore] = useState(initialScore);
+
+  // Keep score in sync if the caller provides a new initialScore
+  useEffect(() => {
+    setScore(initialScore);
+  }, [initialScore]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function updateScore() {
+      try {
+        const newScore = fetchScore
+          ? await fetchScore(playerId)
+          : await fetch(`/api/players/${playerId}/score`).then((res) => res.json()).then((data) => data.score);
+        if (active && typeof newScore === 'number') {
+          setScore(newScore);
+        }
+      } catch {
+        // Swallow errors to keep UI responsive
+      }
+    }
+
+    const interval = setInterval(updateScore, 10000);
+    updateScore();
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [playerId, fetchScore]);
+
+  return score;
+}
+
+export default useLivePlayerScore;


### PR DESCRIPTION
## Summary
- provide a polling hook `useLivePlayerScore` for retrieving live player scores
- update `PlayerCard` to consume live scores and accept an override via `liveScore` prop
- verify real-time updates via updated component tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7090938e0832ea0fe9e031d2c1413