### PR TITLE
feat: centralize environment variable validation

### DIFF
--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -5,6 +5,7 @@ import { createClient } from '@/utils/supabase/server';
 import { getCurrentNflWeek } from '@/app/actions';
 import logger from '@/utils/logger';
 import { fetchJson } from '@/lib/fetch-json';
+import { env } from '@/lib/env';
 
 /**
  * Parses the team data from the Yahoo API response.
@@ -57,17 +58,9 @@ export async function getYahooAccessToken(integrationId: number): Promise<{ acce
   // Check if the token is expired or close to expiring (e.g., within 60 seconds)
   if (integration.expires_at && new Date(integration.expires_at).getTime() < Date.now() + 60000) {
     // Token is expired, refresh it
-    const clientId = process.env.YAHOO_CLIENT_ID;
-    const clientSecret = process.env.YAHOO_CLIENT_SECRET;
-    const redirectUri = process.env.YAHOO_REDIRECT_URI;
-
-    if (!clientId || !clientSecret || !redirectUri) {
-      const missingVars = [];
-      if (!clientId) missingVars.push('YAHOO_CLIENT_ID');
-      if (!clientSecret) missingVars.push('YAHOO_CLIENT_SECRET');
-      if (!redirectUri) missingVars.push('YAHOO_REDIRECT_URI');
-      return { error: `Yahoo integration is not configured. Missing environment variables: ${missingVars.join(', ')}` };
-    }
+    const clientId = env.YAHOO_CLIENT_ID;
+    const clientSecret = env.YAHOO_CLIENT_SECRET;
+    const redirectUri = env.YAHOO_REDIRECT_URI;
 
     const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
 
@@ -80,7 +73,7 @@ export async function getYahooAccessToken(integrationId: number): Promise<{ acce
         },
         body: new URLSearchParams({
           grant_type: 'refresh_token',
-          redirect_uri: process.env.YAHOO_REDIRECT_URI!,
+          redirect_uri: redirectUri,
           refresh_token: integration.refresh_token!,
         }),
       });

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,0 +1,37 @@
+describe('env validation', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('exports env when variables are valid', async () => {
+    process.env.YAHOO_CLIENT_ID = 'id';
+    process.env.YAHOO_CLIENT_SECRET = 'secret';
+    process.env.YAHOO_REDIRECT_URI = 'https://example.com';
+
+    const { env } = await import('./env');
+    expect(env.YAHOO_CLIENT_ID).toBe('id');
+  });
+
+  it('throws error when variables are missing', async () => {
+    delete process.env.YAHOO_CLIENT_ID;
+    delete process.env.YAHOO_CLIENT_SECRET;
+    delete process.env.YAHOO_REDIRECT_URI;
+
+    await expect(import('./env')).rejects.toThrow(/Invalid environment variables/);
+  });
+
+  it('throws error when redirect uri is invalid', async () => {
+    process.env.YAHOO_CLIENT_ID = 'id';
+    process.env.YAHOO_CLIENT_SECRET = 'secret';
+    process.env.YAHOO_REDIRECT_URI = 'not-a-url';
+
+    await expect(import('./env')).rejects.toThrow(/YAHOO_REDIRECT_URI/);
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  YAHOO_CLIENT_ID: z.string().min(1),
+  YAHOO_CLIENT_SECRET: z.string().min(1),
+  YAHOO_REDIRECT_URI: z.string().url(),
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  const errors = parsed.error.issues
+    .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+    .join('; ');
+  throw new Error(`Invalid environment variables: ${errors}`);
+}
+
+export const env = parsed.data;
+


### PR DESCRIPTION
## Summary
- add `env` module using Zod to validate Yahoo environment variables
- use shared env config in Yahoo integration actions
- test env schema and Yahoo actions with validated variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c70c77c720832eabb3cf619d2b53a3