### PR TITLE
Use DOM parser for Ottoneu integration

### DIFF
--- a/src/app/integrations/ottoneu/actions.test.ts
+++ b/src/app/integrations/ottoneu/actions.test.ts
@@ -71,6 +71,51 @@ describe('ottoneu actions', () => {
     });
   });
 
+  it('parses matchup when team is the away team', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<span class="teamName">My Team</span><a href="/football/309/"><span class="desktop-navigation">My League</span></a><div class="page-header__section"><h4>Week 3 Matchup</h4><br><ul class="other-games"><li id="game-1"><div class="game-status">LIVE</div><div><a href="/football/309/game/2"><div class="other-game-home-team">Opponent<span class="other-game-score home-score">10.00</span></div><div class="other-game-away-team">My Team<span class="other-game-score away-score">5.00</span></div></a></div></li></ul></div>'
+        ),
+    });
+    const result = await getOttoneuTeamInfo(
+      'https://ottoneu.fangraphs.com/football/309/team/2514'
+    );
+    expect(result).toEqual({
+      teamName: 'My Team',
+      leagueName: 'My League',
+      leagueId: '309',
+      teamId: '2514',
+      matchup: {
+        week: 3,
+        opponentName: 'Opponent',
+        teamScore: 5,
+        opponentScore: 10,
+        url: '/football/309/game/2',
+      },
+    });
+  });
+
+  it('falls back to league name span when anchor does not match league id', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<span class="teamName">My Team</span><a href="/football/309/?foo=bar"><span class="desktop-navigation">My League</span></a>'
+        ),
+    });
+    const result = await getOttoneuTeamInfo(
+      'https://ottoneu.fangraphs.com/football/309/team/2514'
+    );
+    expect(result).toEqual({
+      teamName: 'My Team',
+      leagueName: 'My League',
+      leagueId: '309',
+      teamId: '2514',
+    });
+  });
+
   it('returns error on invalid url', async () => {
     const result = await getOttoneuTeamInfo('https://example.com');
     expect(result).toEqual({ error: 'Invalid Ottoneu team URL.' });


### PR DESCRIPTION
## Summary
- replace brittle regex parsing with jsdom DOM parsing
- handle matchup extraction by mapping DOM home/away elements
- add tests for varied Ottoneu HTML structures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7423b1ba4832e83abb01a9f9a4c27