### PR TITLE
Highlight double agent players

### DIFF
--- a/e2e/mocks/external-apis.js
+++ b/e2e/mocks/external-apis.js
@@ -39,14 +39,31 @@ global.fetch = async (input, init) => {
   if (url === 'https://api.sleeper.app/v1/league/league1/rosters') {
     return jsonResponse([
       { roster_id: 1, owner_id: 'sleeperUser', players: ['p1'], starters: ['p1'] },
-      { roster_id: 2, owner_id: 'opponentUser', players: ['p2'], starters: ['p2'] },
+      {
+        roster_id: 2,
+        owner_id: 'opponentUser',
+        players: ['p2', 'p3'],
+        starters: ['p2', 'p3'],
+      },
     ]);
   }
 
   if (url === 'https://api.sleeper.app/v1/league/league1/matchups/1') {
     return jsonResponse([
-      { roster_id: 1, matchup_id: 1, players_points: { p1: 10 }, players: ['p1'] },
-      { roster_id: 2, matchup_id: 1, players_points: { p2: 8 }, players: ['p2'] },
+      {
+        roster_id: 1,
+        matchup_id: 1,
+        points: 10,
+        players_points: { p1: 10 },
+        players: ['p1'],
+      },
+      {
+        roster_id: 2,
+        matchup_id: 1,
+        points: 8,
+        players_points: { p2: 8, p3: 0 },
+        players: ['p2', 'p3'],
+      },
     ]);
   }
 

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -68,14 +68,21 @@ function AppContent({ onSignOut, teams }: { onSignOut: () => void, teams: Team[]
     players.forEach(player => {
       if (player && player.name && player.realTeam) {
         const key = `${player.name.toLowerCase()}-${player.realTeam.toLowerCase()}`;
+        const isDoubleAgent = player.onUserTeams > 0 && player.onOpponentTeams > 0;
         if (existingPlayers.has(key)) {
           const existingPlayer = existingPlayers.get(key)!;
           existingPlayer.count++;
           if (!existingPlayer.matchupColors.includes(color)) {
             existingPlayer.matchupColors.push(color);
           }
+          existingPlayer.isDoubleAgent = existingPlayer.isDoubleAgent || isDoubleAgent;
         } else {
-          existingPlayers.set(key, { ...player, count: 1, matchupColors: [color] });
+          existingPlayers.set(key, {
+            ...player,
+            count: 1,
+            matchupColors: [color],
+            isDoubleAgent,
+          });
         }
       }
     });

--- a/src/components/player-card.test.tsx
+++ b/src/components/player-card.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { PlayerCard } from '@/components/player-card'
-import type { Player } from '@/lib/types'
+import type { GroupedPlayer } from '@/lib/types'
 
 describe('PlayerCard', () => {
-  const player: Player = {
-    id: 1,
+  const player: GroupedPlayer = {
+    id: '1',
     name: 'Test Player',
     position: 'QB',
     realTeam: 'TB',
@@ -18,6 +18,10 @@ describe('PlayerCard', () => {
       fieldPosition: 'TB 20',
     },
     imageUrl: 'https://example.com/player.jpg',
+    on_bench: false,
+    count: 1,
+    matchupColors: ['#000000'],
+    isDoubleAgent: false,
   }
 
   it('renders player information', () => {
@@ -26,5 +30,21 @@ describe('PlayerCard', () => {
     expect(screen.getByText('QB - TB')).toBeInTheDocument()
     expect(screen.getByText('10.5')).toBeInTheDocument()
     expect(screen.queryByText('Possession')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('double-agent-badge')).not.toBeInTheDocument()
+  })
+
+  it('renders a double agent badge when the player is on user and opponent teams', () => {
+    const doubleAgent: GroupedPlayer = {
+      ...player,
+      id: '2',
+      name: 'Double Agent',
+      onOpponentTeams: 2,
+      isDoubleAgent: true,
+    }
+
+    render(<PlayerCard player={doubleAgent} />)
+
+    expect(screen.getByText('Double Agent')).toBeInTheDocument()
+    expect(screen.getByTestId('double-agent-badge')).toBeInTheDocument()
   })
 })

--- a/src/components/player-card.tsx
+++ b/src/components/player-card.tsx
@@ -2,6 +2,8 @@
 
 import type { GroupedPlayer } from "@/lib/types";
 import { Card } from "@/components/ui/card";
+import { badgeVariants } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 import Image from "next/image";
 import { User, Users } from "lucide-react";
 import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -19,6 +21,29 @@ export function PlayerCard({ player }: { player: GroupedPlayer }) {
                 <div className="flex-1 mx-2 min-w-0">
                     <div className="flex items-center gap-2">
                         <p className="text-xs sm:text-sm font-semibold leading-tight">{player.name}</p>
+                        {player.isDoubleAgent && (
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <span
+                                        data-testid="double-agent-badge"
+                                        aria-label="Also rostered by opponents this week"
+                                        tabIndex={0}
+                                        className={cn(
+                                            badgeVariants({ variant: "secondary" }),
+                                            "gap-1 px-1.5 py-0.5 text-[10px] sm:text-xs"
+                                        )}
+                                    >
+                                        <span role="img" aria-hidden="true" className="text-sm leading-none">
+                                            🕵️
+                                        </span>
+                                        <span className="sr-only">Double agent</span>
+                                    </span>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Also rostered by opponents this week</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        )}
                         <div className="flex items-center gap-1">
                             {player.matchupColors.map((color, index) => (
                                 <div key={index} className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,8 @@ export type GroupedPlayer = Player & {
   count: number;
   /** The colors of the matchups this player is in. */
   matchupColors: string[];
+  /** Indicates the player is rostered by both you and an opponent. */
+  isDoubleAgent: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary
- flag grouped players as double agents when they appear on both user and opponent rosters
- display a tooltip badge on the player card when the player is also rostered by an opponent
- extend the player card test coverage for the new badge behaviour

## Testing
- npm test -- player-card

------
https://chatgpt.com/codex/tasks/task_e_68c83fcd7c84832eb84363e409910b37