### PR TITLE
Rename Player bench flag to camelCase

### DIFF
--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -174,7 +174,7 @@ describe('actions', () => {
               name: 'Player One',
               display_position: 'QB',
               editorial_team_abbr: 'TEAMC',
-              on_bench: false,
+              onBench: false,
               headshot: 'img1',
             },
           ],
@@ -187,7 +187,7 @@ describe('actions', () => {
               name: 'Player Two',
               display_position: 'WR',
               editorial_team_abbr: 'TEAMD',
-              on_bench: false,
+              onBench: false,
               headshot: 'img2',
             },
           ],
@@ -313,7 +313,7 @@ describe('actions', () => {
 
       (getYahooRoster as jest.Mock)
         .mockResolvedValue({
-          players: [{ player_key: 'p1', name: 'Player One', display_position: 'QB', editorial_team_abbr: 'TEAMC', on_bench: false }],
+          players: [{ player_key: 'p1', name: 'Player One', display_position: 'QB', editorial_team_abbr: 'TEAMC', onBench: false }],
           error: null,
         });
 
@@ -422,7 +422,7 @@ describe('actions', () => {
       });
 
       (getYahooRoster as jest.Mock).mockResolvedValue({
-        players: [{ player_key: 'p1', name: 'Player One', display_position: 'QB', editorial_team_abbr: 'TEAMC', on_bench: false }],
+        players: [{ player_key: 'p1', name: 'Player One', display_position: 'QB', editorial_team_abbr: 'TEAMC', onBench: false }],
         error: null,
       });
 
@@ -468,7 +468,7 @@ describe('actions', () => {
       });
 
       (getYahooRoster as jest.Mock).mockResolvedValue({
-        players: [{ player_key: 'p1', name: 'Player One', display_position: 'QB', editorial_team_abbr: 'TEAMC', on_bench: false }],
+        players: [{ player_key: 'p1', name: 'Player One', display_position: 'QB', editorial_team_abbr: 'TEAMC', onBench: false }],
         error: null,
       });
 
@@ -520,7 +520,7 @@ describe('actions', () => {
 
       (getYahooRoster as jest.Mock).mockResolvedValue({
         players: [
-          { player_key: 'p1', name: 'Player 1', display_position: 'QB', editorial_team_abbr: 'TEAMC', on_bench: false },
+          { player_key: 'p1', name: 'Player 1', display_position: 'QB', editorial_team_abbr: 'TEAMC', onBench: false },
         ],
         error: null,
       });
@@ -609,9 +609,9 @@ describe('actions', () => {
         position: 'QB',
         realTeam: 'CHI',
         score: 5,
-        on_bench: false,
+        onBench: false,
       });
-      expect(result.teams[0].players[1].on_bench).toBe(true);
+      expect(result.teams[0].players[1].onBench).toBe(true);
       expect(result.teams[0].opponent.players).toHaveLength(2);
       expect(result.teams[0].opponent.players[0]).toMatchObject({
         id: '2',

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -120,7 +120,7 @@ export async function buildSleeperTeams(
         onOpponentTeams: 0,
         gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
         imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
-        on_bench: !userRoster.starters.includes(playerId),
+        onBench: !userRoster.starters.includes(playerId),
       };
     });
 
@@ -141,7 +141,7 @@ export async function buildSleeperTeams(
               onOpponentTeams: 0,
               gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
               imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
-              on_bench: !opponentRoster.starters.includes(playerId),
+              onBench: !opponentRoster.starters.includes(playerId),
             };
           })
         : [];
@@ -259,7 +259,7 @@ export async function buildYahooTeams(
         onOpponentTeams: 0,
         gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
         imageUrl: imageUrl,
-        on_bench: p.on_bench,
+        onBench: p.onBench,
       };
     };
 
@@ -356,7 +356,7 @@ export async function buildOttoneuTeams(integration: any): Promise<Team[]> {
             onOpponentTeams: 0,
             gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
             imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${id}.jpg`,
-            on_bench: onBench,
+            onBench: onBench,
           };
         };
 

--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -502,7 +502,7 @@ export async function getYahooRoster(integrationId: number, leagueId: string, te
         is_undroppable: playerDetails.is_undroppable,
         position_type: playerDetails.position_type,
         eligible_positions: playerDetails.eligible_positions?.map((pos: any) => pos.position),
-        on_bench: selectedPosition === 'BN',
+        onBench: selectedPosition === 'BN',
       };
     }).filter(Boolean); // Filter out any null entries from failed parsing
 

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -93,10 +93,10 @@ function AppContent({ onSignOut, teams }: { onSignOut: () => void, teams: Team[]
   const myPlayers = Array.from(myPlayersMap.values());
   const opponentPlayers = Array.from(opponentPlayersMap.values());
 
-  const myStarters = myPlayers.filter(p => !p.on_bench);
-  const myBench = myPlayers.filter(p => p.on_bench);
-  const opponentStarters = opponentPlayers.filter(p => !p.on_bench);
-  const opponentBench = opponentPlayers.filter(p => p.on_bench);
+  const myStarters = myPlayers.filter(p => !p.onBench);
+  const myBench = myPlayers.filter(p => p.onBench);
+  const opponentStarters = opponentPlayers.filter(p => !p.onBench);
+  const opponentBench = opponentPlayers.filter(p => p.onBench);
 
   const myPlayersByPosition = groupPlayersByPosition(myStarters);
   const opponentPlayersByPosition = groupPlayersByPosition(opponentStarters);

--- a/src/components/player-card.test.tsx
+++ b/src/components/player-card.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { PlayerCard } from '@/components/player-card'
-import type { Player } from '@/lib/types'
+import type { GroupedPlayer } from '@/lib/types'
 
 describe('PlayerCard', () => {
-  const player: Player = {
-    id: 1,
+  const player: GroupedPlayer = {
+    id: '1',
     name: 'Test Player',
     position: 'QB',
     realTeam: 'TB',
@@ -18,6 +18,9 @@ describe('PlayerCard', () => {
       fieldPosition: 'TB 20',
     },
     imageUrl: 'https://example.com/player.jpg',
+    onBench: false,
+    matchupColors: ['#000000'],
+    count: 1,
   }
 
   it('renders player information', () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,7 +58,7 @@ export type Player = {
   /** The URL of the player's image. */
   imageUrl: string;
   /** Whether the player is on the bench. */
-  on_bench: boolean;
+  onBench: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary
- rename the `Player.on_bench` flag to `onBench` and document the camelCase property
- update team builders, Yahoo roster mapping, and UI consumers to read and write the new bench flag
- refresh related unit tests to reflect the renamed property and valid grouped player fixtures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9c2a8cdd4832e9c8ee514af7ea98e