### PR TITLE
Improve Sleeper data retrieval concurrency

### DIFF
--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -128,6 +128,26 @@ describe('actions', () => {
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Team A');
     });
+
+    it('skips leagues when sleeper data is incomplete', async () => {
+      (getLeagues as jest.Mock).mockResolvedValue({
+        leagues: [{ id: 1, league_id: 'sleeper-league-1' }],
+        error: null,
+      });
+
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({ json: () => Promise.resolve(null) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockMatchups) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockLeagueUsers) });
+
+      const result = await buildSleeperTeams(
+        { id: 1, provider_user_id: 'sleeper-user-1' },
+        1,
+        mockPlayersData
+      );
+
+      expect(result).toEqual([]);
+    });
   });
 
   describe('buildYahooTeams', () => {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -55,15 +55,25 @@ export async function buildSleeperTeams(
   const teams: Team[] = [];
 
   for (const league of leagues as SleeperLeague[]) {
-    const rostersResponse = await fetch(
-      `https://api.sleeper.app/v1/league/${league.league_id}/rosters`
-    );
-    const rosters: SleeperRoster[] = await rostersResponse.json();
+    const [rosters, matchups, leagueUsers] = await Promise.all([
+      fetch(`https://api.sleeper.app/v1/league/${league.league_id}/rosters`).then(
+        (response) => response.json() as Promise<SleeperRoster[]>
+      ),
+      fetch(
+        `https://api.sleeper.app/v1/league/${league.league_id}/matchups/${week}`
+      ).then((response) => response.json() as Promise<SleeperMatchup[]>),
+      fetch(`https://api.sleeper.app/v1/league/${league.league_id}/users`).then(
+        (response) => response.json() as Promise<SleeperUser[]>
+      ),
+    ]);
 
-    const matchupsResponse = await fetch(
-      `https://api.sleeper.app/v1/league/${league.league_id}/matchups/${week}`
-    );
-    const matchups: SleeperMatchup[] = await matchupsResponse.json();
+    if (
+      !Array.isArray(rosters) ||
+      !Array.isArray(matchups) ||
+      !Array.isArray(leagueUsers)
+    ) {
+      continue;
+    }
 
     const userRoster = rosters.find(
       (roster) => roster.owner_id === integration.provider_user_id
@@ -84,11 +94,6 @@ export async function buildSleeperTeams(
     const opponentRoster = opponentMatchup
       ? rosters.find((roster) => roster.roster_id === opponentMatchup.roster_id) || null
       : null;
-
-    const leagueUsersResponse = await fetch(
-      `https://api.sleeper.app/v1/league/${league.league_id}/users`
-    );
-    const leagueUsers: SleeperUser[] = await leagueUsersResponse.json();
 
     const userLeagueInfo = leagueUsers.find(
       (user) => user.user_id === integration.provider_user_id


### PR DESCRIPTION
## Summary
- fetch Sleeper rosters, matchups, and league users in parallel when building teams
- skip league processing when any Sleeper response is missing to preserve existing safeguards
- add a regression test covering the incomplete Sleeper data scenario

## Testing
- npm test -- src/app/actions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9c887da98832ebe85d977c2122849