### PR TITLE
Refactor Sleeper player mapping

### DIFF
--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -1,5 +1,5 @@
 import * as actions from './actions';
-const { getTeams, buildSleeperTeams, buildYahooTeams } = actions;
+const { getTeams, buildSleeperTeams, buildYahooTeams, mapSleeperPlayer } = actions;
 import { SleeperRoster, SleeperMatchup, SleeperUser, SleeperPlayer } from '@/lib/types';
 import { createClient } from '@/utils/supabase/server';
 import { getLeagues } from '@/app/integrations/sleeper/actions';
@@ -66,6 +66,61 @@ describe('actions', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+  });
+
+  describe('mapSleeperPlayer', () => {
+    const matchup: SleeperMatchup = {
+      roster_id: 1,
+      matchup_id: 1,
+      points: 0,
+      players: ['1'],
+      players_points: { '1': 12 },
+    };
+
+    const roster: SleeperRoster = {
+      owner_id: 'sleeper-user-1',
+      roster_id: 1,
+      players: ['1'],
+      starters: ['1'],
+    };
+
+    const playersData: Record<string, SleeperPlayer> = {
+      '1': { full_name: 'Player One', position: 'QB', team: 'TEAMA' },
+    };
+
+    it('maps player data when Sleeper information exists', () => {
+      const result = mapSleeperPlayer({
+        playerId: '1',
+        playersData,
+        matchup,
+        roster,
+      });
+
+      expect(result).toEqual({
+        id: '1',
+        name: 'Player One',
+        position: 'QB',
+        realTeam: 'TEAMA',
+        score: 12,
+        gameStatus: 'pregame',
+        onUserTeams: 0,
+        onOpponentTeams: 0,
+        gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
+        imageUrl: 'https://sleepercdn.com/content/nfl/players/thumb/1.jpg',
+        onBench: false,
+      });
+    });
+
+    it('returns null when player data is not available', () => {
+      const result = mapSleeperPlayer({
+        playerId: 'unknown',
+        playersData,
+        matchup,
+        roster,
+      });
+
+      expect(result).toBeNull();
+    });
   });
 
   describe('buildSleeperTeams', () => {
@@ -147,6 +202,55 @@ describe('actions', () => {
       );
 
       expect(result).toEqual([]);
+    });
+
+    it('omits players without Sleeper player data', async () => {
+      (getLeagues as jest.Mock).mockResolvedValue({
+        leagues: [{ id: 1, league_id: 'sleeper-league-1' }],
+        error: null,
+      });
+
+      const playersDataWithMissing: Record<string, SleeperPlayer> = {
+        '1': { full_name: 'Player One', position: 'QB', team: 'TEAMA' },
+      };
+
+      const rostersWithUnknown: SleeperRoster[] = [
+        { owner_id: 'sleeper-user-1', roster_id: 1, players: ['1'], starters: ['1'] },
+        { owner_id: 'sleeper-user-2', roster_id: 2, players: ['3'], starters: ['3'] },
+      ];
+
+      const matchupsWithUnknown: SleeperMatchup[] = [
+        {
+          roster_id: 1,
+          matchup_id: 1,
+          points: 100,
+          players_points: { '1': 20 },
+          players: ['1'],
+        },
+        {
+          roster_id: 2,
+          matchup_id: 1,
+          points: 90,
+          players_points: { '3': 15 },
+          players: ['3'],
+        },
+      ];
+
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({ json: () => Promise.resolve(rostersWithUnknown) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(matchupsWithUnknown) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockLeagueUsers) });
+
+      const result = await buildSleeperTeams(
+        { id: 1, provider_user_id: 'sleeper-user-1' },
+        1,
+        playersDataWithMissing
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].players).toHaveLength(1);
+      expect(result[0].players[0].id).toBe('1');
+      expect(result[0].opponent.players).toEqual([]);
     });
   });
 

--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -1,5 +1,6 @@
 import * as actions from './actions';
-const { getTeams, buildSleeperTeams, buildYahooTeams, mapSleeperPlayer } = actions;
+const { getTeams, buildSleeperTeams, buildYahooTeams } = actions;
+import { mapSleeperPlayer } from '@/lib/sleeper';
 import { SleeperRoster, SleeperMatchup, SleeperUser, SleeperPlayer } from '@/lib/types';
 import { createClient } from '@/utils/supabase/server';
 import { getLeagues } from '@/app/integrations/sleeper/actions';

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -13,6 +13,7 @@ import {
   getLeagues as getOttoneuLeagues,
   getOttoneuTeamInfo,
 } from '@/app/integrations/ottoneu/actions';
+import { mapSleeperPlayer } from '@/lib/sleeper';
 import {
   Team,
   Player,
@@ -33,49 +34,6 @@ export async function getCurrentNflWeek() {
   const nflStateResponse = await fetch('https://api.sleeper.app/v1/state/nfl');
   const nflState = await nflStateResponse.json();
   return nflState.week;
-}
-
-type MapSleeperPlayerParams = {
-  playerId: string;
-  playersData: Record<string, SleeperPlayer>;
-  matchup: SleeperMatchup;
-  roster: SleeperRoster | null;
-};
-
-/**
- * Maps a Sleeper player ID to the internal Player representation.
- * Returns null when player data cannot be found.
- */
-export function mapSleeperPlayer({
-  playerId,
-  playersData,
-  matchup,
-  roster,
-}: MapSleeperPlayerParams): Player | null {
-  const player = playersData[playerId];
-  if (!player) {
-    return null;
-  }
-
-  const starters = roster?.starters ?? [];
-  const computedName =
-    player.full_name ||
-    [player.first_name, player.last_name].filter(Boolean).join(' ');
-  const name = computedName?.trim() ? computedName.trim() : 'Unknown Player';
-
-  return {
-    id: playerId,
-    name,
-    position: player.position ?? '',
-    realTeam: player.team ?? '',
-    score: matchup.players_points?.[playerId] ?? 0,
-    gameStatus: 'pregame',
-    onUserTeams: 0,
-    onOpponentTeams: 0,
-    gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
-    imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
-    onBench: !starters.includes(playerId),
-  };
 }
 
 /**

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -35,6 +35,49 @@ export async function getCurrentNflWeek() {
   return nflState.week;
 }
 
+type MapSleeperPlayerParams = {
+  playerId: string;
+  playersData: Record<string, SleeperPlayer>;
+  matchup: SleeperMatchup;
+  roster: SleeperRoster | null;
+};
+
+/**
+ * Maps a Sleeper player ID to the internal Player representation.
+ * Returns null when player data cannot be found.
+ */
+export function mapSleeperPlayer({
+  playerId,
+  playersData,
+  matchup,
+  roster,
+}: MapSleeperPlayerParams): Player | null {
+  const player = playersData[playerId];
+  if (!player) {
+    return null;
+  }
+
+  const starters = roster?.starters ?? [];
+  const computedName =
+    player.full_name ||
+    [player.first_name, player.last_name].filter(Boolean).join(' ');
+  const name = computedName?.trim() ? computedName.trim() : 'Unknown Player';
+
+  return {
+    id: playerId,
+    name,
+    position: player.position ?? '',
+    realTeam: player.team ?? '',
+    score: matchup.players_points?.[playerId] ?? 0,
+    gameStatus: 'pregame',
+    onUserTeams: 0,
+    onOpponentTeams: 0,
+    gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
+    imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
+    onBench: !starters.includes(playerId),
+  };
+}
+
 /**
  * Builds teams for a Sleeper integration.
  * @param integration The sleeper integration record.
@@ -111,44 +154,29 @@ export async function buildSleeperTeams(
       opponentUser?.display_name ||
       'Opponent';
 
-    const userPlayers = userMatchup.players.map((playerId: string) => {
-      const player = playersData[playerId];
-      const score = userMatchup.players_points?.[playerId] ?? 0;
-      return {
-        id: playerId,
-        name: player.full_name,
-        position: player.position,
-        realTeam: player.team,
-        score: score,
-        gameStatus: 'pregame',
-        onUserTeams: 0,
-        onOpponentTeams: 0,
-        gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
-        imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
-        onBench: !userRoster.starters.includes(playerId),
-      };
-    });
+    const userPlayers = userMatchup.players
+      .map((playerId: string) =>
+        mapSleeperPlayer({
+          playerId,
+          playersData,
+          matchup: userMatchup,
+          roster: userRoster,
+        })
+      )
+      .filter((player): player is Player => player !== null);
 
     const opponentPlayers =
       opponentMatchup && opponentMatchup.players
-        ? opponentMatchup.players.map((playerId: string) => {
-            const player = playersData[playerId];
-            const score = opponentMatchup.players_points?.[playerId] ?? 0;
-
-            return {
-              id: playerId,
-              name: player.full_name,
-              position: player.position,
-              realTeam: player.team,
-              score: score,
-              gameStatus: 'pregame',
-              onUserTeams: 0,
-              onOpponentTeams: 0,
-              gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
-              imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
-              onBench: !opponentRoster.starters.includes(playerId),
-            };
-          })
+        ? opponentMatchup.players
+            .map((playerId: string) =>
+              mapSleeperPlayer({
+                playerId,
+                playersData,
+                matchup: opponentMatchup,
+                roster: opponentRoster,
+              })
+            )
+            .filter((player): player is Player => player !== null)
         : [];
 
     teams.push({

--- a/src/lib/sleeper.ts
+++ b/src/lib/sleeper.ts
@@ -1,0 +1,49 @@
+import {
+  Player,
+  SleeperMatchup,
+  SleeperPlayer,
+  SleeperRoster,
+} from '@/lib/types';
+
+export type MapSleeperPlayerParams = {
+  playerId: string;
+  playersData: Record<string, SleeperPlayer>;
+  matchup: SleeperMatchup;
+  roster: SleeperRoster | null;
+};
+
+/**
+ * Maps a Sleeper player ID to the internal Player representation.
+ * Returns null when player data cannot be found.
+ */
+export function mapSleeperPlayer({
+  playerId,
+  playersData,
+  matchup,
+  roster,
+}: MapSleeperPlayerParams): Player | null {
+  const player = playersData[playerId];
+  if (!player) {
+    return null;
+  }
+
+  const starters = roster?.starters ?? [];
+  const computedName =
+    player.full_name ||
+    [player.first_name, player.last_name].filter(Boolean).join(' ');
+  const name = computedName?.trim() ? computedName.trim() : 'Unknown Player';
+
+  return {
+    id: playerId,
+    name,
+    position: player.position ?? '',
+    realTeam: player.team ?? '',
+    score: matchup.players_points?.[playerId] ?? 0,
+    gameStatus: 'pregame',
+    onUserTeams: 0,
+    onOpponentTeams: 0,
+    gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
+    imageUrl: `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`,
+    onBench: !starters.includes(playerId),
+  };
+}


### PR DESCRIPTION
## Summary
- extract a reusable `mapSleeperPlayer` helper that normalizes Sleeper player data and skips unknown entries
- use the helper for both user and opponent roster mapping in `buildSleeperTeams`
- add unit coverage for the helper and missing Sleeper player scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9cd9be770832e9cdea8a64499fa58