### PR TITLE
Add caching controls to fetchJson

### DIFF
--- a/src/app/integrations/sleeper/actions.test.ts
+++ b/src/app/integrations/sleeper/actions.test.ts
@@ -11,7 +11,10 @@ describe('sleeper actions', () => {
   it('returns matchups on success', async () => {
     (fetchJson as jest.Mock).mockResolvedValue({ data: [{ id: 1 }] });
     const result = await getMatchups('league', '1');
-    expect(fetchJson).toHaveBeenCalledWith('https://api.sleeper.app/v1/league/league/matchups/1');
+    expect(fetchJson).toHaveBeenCalledWith(
+      'https://api.sleeper.app/v1/league/league/matchups/1',
+      { disableCache: true }
+    );
     expect(result).toEqual({ matchups: [{ id: 1 }] });
   });
 

--- a/src/app/integrations/sleeper/actions.ts
+++ b/src/app/integrations/sleeper/actions.ts
@@ -178,7 +178,9 @@ export async function getSleeperLeagues(userId: string, integrationId: number) {
 export async function getMatchups(leagueId: string, week: string) {
   try {
     const url = `https://api.sleeper.app/v1/league/${leagueId}/matchups/${week}`;
-    const { data: matchups, error } = await fetchJson<SleeperMatchup[]>(url);
+    const { data: matchups, error } = await fetchJson<SleeperMatchup[]>(url, {
+      disableCache: true,
+    });
     if (error) {
       return { error };
     }

--- a/src/app/integrations/yahoo/actions.test.ts
+++ b/src/app/integrations/yahoo/actions.test.ts
@@ -90,6 +90,14 @@ describe('yahoo actions', () => {
     fetchJson.mockResolvedValue({ data: playerScoresExample });
     const result = await actions.getYahooPlayerScores(1, 'teamKey');
 
+    expect(fetchJson).toHaveBeenCalledWith(
+      'https://fantasysports.yahooapis.com/fantasy/v2/team/teamKey/roster;week=2/players/stats?format=json',
+      expect.objectContaining({
+        disableCache: true,
+        headers: expect.objectContaining({ Authorization: 'Bearer token' }),
+      }),
+    );
+
     expect(result.players[0]).toMatchObject({
       player_key: '461.p.40896',
       name: 'Jayden Daniels',

--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -602,6 +602,7 @@ export async function getYahooPlayerScores(integrationId: number, teamKey: strin
         'Authorization': `Bearer ${access_token}`,
         'Accept': 'application/json',
       },
+      disableCache: true,
     });
 
     if (error) {

--- a/src/lib/fetch-json.test.ts
+++ b/src/lib/fetch-json.test.ts
@@ -8,6 +8,7 @@ describe('fetchJson', () => {
   it('returns data when response is ok', async () => {
     (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve({ a: 1 }) });
     const result = await fetchJson<{ a: number }>('/test');
+    expect(fetch).toHaveBeenCalledWith('/test', { next: { revalidate: 3600 } });
     expect(result).toEqual({ data: { a: 1 } });
   });
 
@@ -15,5 +16,32 @@ describe('fetchJson', () => {
     (fetch as jest.Mock).mockResolvedValue({ ok: false, statusText: 'Bad', json: () => Promise.resolve({ message: 'fail' }) });
     const result = await fetchJson('/test');
     expect(result).toEqual({ error: 'fail' });
+  });
+
+  it('disables caching when disableCache is true', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    await fetchJson('/test', { disableCache: true });
+
+    expect(fetch).toHaveBeenCalledWith('/test', {
+      cache: 'no-store',
+      next: { revalidate: 0 },
+    });
+  });
+
+  it('does not override an existing revalidate value', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    await fetchJson('/test', { next: { revalidate: 10 } });
+
+    expect(fetch).toHaveBeenCalledWith('/test', { next: { revalidate: 10 } });
+  });
+
+  it('does not enable caching for non-GET requests', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    await fetchJson('/test', { method: 'POST' });
+
+    expect(fetch).toHaveBeenCalledWith('/test', { method: 'POST' });
   });
 });


### PR DESCRIPTION
## Summary
- add a default 1-hour Next.js revalidate window to fetchJson while allowing callers to disable caching
- extend fetchJson test coverage for caching behaviour and honouring explicit revalidate options
- call fetchJson with caching disabled for Yahoo player score fetches and verify this path in tests

## Testing
- npm test -- --runInBand fetch-json actions
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f8f90958832eb0d5f12d1d10106c