### PR TITLE
Add refresh button for matchup scores

### DIFF
--- a/src/app/api/teams/refresh/route.ts
+++ b/src/app/api/teams/refresh/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { getTeams } from '@/app/actions';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Fetches the latest teams and scores from all configured providers.
+ */
+export async function POST() {
+  try {
+    const result = await getTeams();
+
+    if ('error' in result) {
+      const status = result.error === 'You must be logged in.' ? 401 : 500;
+      return NextResponse.json({ error: result.error }, { status });
+    }
+
+    return NextResponse.json({ teams: result.teams });
+  } catch (error) {
+    console.error('Failed to refresh teams', error);
+    return NextResponse.json(
+      { error: 'Failed to refresh scores. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/integrations/yahoo/page.tsx
+++ b/src/app/integrations/yahoo/page.tsx
@@ -202,13 +202,13 @@ export default function YahooPage() {
         <CardContent>
           <ul className="list-disc list-inside space-y-2">
             <li>
-              If you see a "Yahoo integration not found" error, please try removing the integration and connecting again.
+              If you see a &quot;Yahoo integration not found&quot; error, please try removing the integration and connecting again.
             </li>
             <li>
-              If your leagues or teams are not showing up, it might be because you don't have any active teams for the current NFL season in your Yahoo account.
+              If your leagues or teams are not showing up, it might be because you don&apos;t have any active teams for the current NFL season in your Yahoo account.
             </li>
             <li>
-              The "Could not find a team for this league" error can happen if your team data is out of sync. Removing and re-adding the integration should resolve this.
+              The &quot;Could not find a team for this league&quot; error can happen if your team data is out of sync. Removing and re-adding the integration should resolve this.
             </li>
           </ul>
         </CardContent>


### PR DESCRIPTION
## Summary
- add a refresh API route that rebuilds teams from all providers on demand
- update the home page to keep team data in state and expose a refresh control with inline error feedback
- escape special characters in the Yahoo troubleshooting copy to satisfy linting

## Testing
- npm run lint
- npm run typecheck *(fails: pre-existing type errors in e2e tests, mock data, and supabase client)*

------
https://chatgpt.com/codex/tasks/task_e_68c9fe69a550832ebe2621b6278b08b4