### PR TITLE
Add loading state for home page

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,17 @@
+import { Loader2 } from 'lucide-react';
+
+/**
+ * Loading treatment shown while the home page is generated on the server.
+ * @returns A centered loading indicator.
+ */
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center">
+      <div className="flex flex-col items-center gap-4" role="status" aria-live="polite">
+        <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">Loading your dashboard&hellip;</p>
+        <span className="sr-only">Loading dashboard content</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an App Router loading fallback for the home page
- show a centered spinner and message while the dashboard data is generated

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca017c75c8832eb2b5c9b0b9241b8a