### PR TITLE
Update Ottoneu integration to use league page lookup

### DIFF
--- a/e2e/goldens/ottoneu_league_page.html
+++ b/e2e/goldens/ottoneu_league_page.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Ottoneu League</title>
+  </head>
+  <body>
+    <table class="standings-table">
+      <tbody>
+        <tr>
+          <td>
+            <a href="https://ottoneu.fangraphs.com/football/309/team/2514">
+              The Witchcraft
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/e2e/mocks/external-apis.js
+++ b/e2e/mocks/external-apis.js
@@ -58,6 +58,10 @@ global.fetch = async (input, init) => {
   }
 
   // Ottoneu page mocks
+  if (url === 'https://ottoneu.fangraphs.com/football/309/') {
+    return htmlResponseFromFile('ottoneu_league_page.html');
+  }
+
   if (url === 'https://ottoneu.fangraphs.com/football/309/team/2514') {
     return htmlResponseFromFile('ottoneu_team_page.html');
   }

--- a/src/app/integrations/ottoneu/page.tsx
+++ b/src/app/integrations/ottoneu/page.tsx
@@ -17,7 +17,8 @@ import { Label } from '@/components/ui/label';
  * Page for managing the Ottoneu integration.
  */
 export default function OttoneuPage() {
-  const [teamUrl, setTeamUrl] = useState('');
+  const [leagueUrl, setLeagueUrl] = useState('');
+  const [teamQuery, setTeamQuery] = useState('');
   const [integration, setIntegration] = useState<any | null>(null);
   const [teamName, setTeamName] = useState('');
   const [leagueName, setLeagueName] = useState('');
@@ -40,6 +41,7 @@ export default function OttoneuPage() {
           const info = await getOttoneuTeamInfo(`https://ottoneu.fangraphs.com/football/${leagues[0].league_id}/team/${integration.provider_user_id}`);
           if ('teamName' in info) {
             setTeamName(info.teamName);
+            setTeamQuery(info.teamName);
           }
           if ('matchup' in info) {
             setMatchup(info.matchup);
@@ -53,16 +55,20 @@ export default function OttoneuPage() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
-    const { teamName, leagueName, error } = await connectOttoneu(teamUrl);
+    const { teamName, leagueName, matchup, error } = await connectOttoneu(
+      leagueUrl,
+      teamQuery
+    );
     if (error) {
       setError(error);
       return;
     }
     setTeamName(teamName);
     setLeagueName(leagueName);
-    const info = await getOttoneuTeamInfo(teamUrl);
-    if ('matchup' in info) {
-      setMatchup(info.matchup);
+    if (matchup) {
+      setMatchup(matchup);
+    } else {
+      setMatchup(null);
     }
     const { integration } = await getOttoneuIntegration();
     setIntegration(integration);
@@ -77,7 +83,8 @@ export default function OttoneuPage() {
       setError(error);
     } else {
       setIntegration(null);
-      setTeamUrl('');
+      setLeagueUrl('');
+      setTeamQuery('');
       setTeamName('');
       setLeagueName('');
       setMatchup(null);
@@ -93,19 +100,28 @@ export default function OttoneuPage() {
           <CardDescription>
             {integration
               ? `Connected to ${teamName || 'your team'} in ${leagueName || 'your league'}`
-              : 'Enter your public team URL to connect.'}
+              : 'Enter your league URL and team name to connect.'}
           </CardDescription>
         </CardHeader>
         <CardContent>
           {!integration ? (
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
-                <Label htmlFor="team-url">Team URL</Label>
+                <Label htmlFor="league-url">League URL</Label>
                 <Input
-                  id="team-url"
+                  id="league-url"
                   type="url"
-                  value={teamUrl}
-                  onChange={(e) => setTeamUrl(e.target.value)}
+                  value={leagueUrl}
+                  onChange={(e) => setLeagueUrl(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="team-name">Team Name</Label>
+                <Input
+                  id="team-name"
+                  value={teamQuery}
+                  onChange={(e) => setTeamQuery(e.target.value)}
                   required
                 />
               </div>


### PR DESCRIPTION
## Summary
- derive Ottoneu team URLs by scraping the league home page standings for the requested team name
- update the Ottoneu integration form to accept a league URL and team name and surface matchup data from the connect flow
- expand mocks, fixtures, and tests to cover the new workflow

## Testing
- npm test -- --runTestsByPath src/app/integrations/ottoneu/actions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc8b9671e0832ea3349d917b889245