### PR TITLE
Add shared navigation bar across application pages

### DIFF
--- a/src/app/(dashboard)/matchup-report/page.tsx
+++ b/src/app/(dashboard)/matchup-report/page.tsx
@@ -1,4 +1,5 @@
 import { getTeams } from "@/app/actions";
+import { AppNavigation } from "@/components/app-navigation";
 import { FantasyHeroes, PublicEnemies, DoubleAgents } from "./components";
 import { processMatchups } from "./utils";
 
@@ -9,13 +10,18 @@ export default async function MatchupReport() {
   );
 
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-3xl font-bold mb-4">Matchup Report</h1>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <FantasyHeroes players={fantasyHeroes} />
-        <PublicEnemies players={publicEnemies} />
-        <DoubleAgents players={doubleAgents} />
-      </div>
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex-1 overflow-y-auto">
+        <div className="container mx-auto space-y-6 p-4 sm:p-6 md:p-8">
+          <h1 className="text-3xl font-bold">Matchup Report</h1>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <FantasyHeroes players={fantasyHeroes} />
+            <PublicEnemies players={publicEnemies} />
+            <DoubleAgents players={doubleAgents} />
+          </div>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -1,5 +1,7 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import Link from 'next/link';
+
+import { AppNavigation } from '@/components/app-navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 /**
  * The integrations page, where users can connect their fantasy football accounts.
@@ -7,47 +9,50 @@ import Link from 'next/link';
  */
 export default function IntegrationsPage() {
   return (
-    <main className="p-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Integrations</CardTitle>
-          <CardDescription>
-            Connect your fantasy football accounts to get started.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Link href="/integrations/sleeper">
-            <Card className="hover:bg-muted">
-              <CardHeader>
-                <CardTitle>Sleeper</CardTitle>
-                <CardDescription>
-                  Connect your Sleeper account to import your leagues.
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          </Link>
-          <Link href="/integrations/yahoo">
-            <Card className="hover:bg-muted">
-              <CardHeader>
-                <CardTitle>Yahoo</CardTitle>
-                <CardDescription>
-                  Connect your Yahoo account to import your leagues.
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          </Link>
-          <Link href="/integrations/ottoneu">
-            <Card className="hover:bg-muted">
-              <CardHeader>
-                <CardTitle>Ottoneu</CardTitle>
-                <CardDescription>
-                  Connect by providing your public team URL.
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          </Link>
-        </CardContent>
-      </Card>
-    </main>
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex-1 p-4 sm:p-6 md:p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Integrations</CardTitle>
+            <CardDescription>
+              Connect your fantasy football accounts to get started.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Link href="/integrations/sleeper">
+              <Card className="hover:bg-muted">
+                <CardHeader>
+                  <CardTitle>Sleeper</CardTitle>
+                  <CardDescription>
+                    Connect your Sleeper account to import your leagues.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </Link>
+            <Link href="/integrations/yahoo">
+              <Card className="hover:bg-muted">
+                <CardHeader>
+                  <CardTitle>Yahoo</CardTitle>
+                  <CardDescription>
+                    Connect your Yahoo account to import your leagues.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </Link>
+            <Link href="/integrations/ottoneu">
+              <Card className="hover:bg-muted">
+                <CardHeader>
+                  <CardTitle>Ottoneu</CardTitle>
+                  <CardDescription>
+                    Connect by providing your public team URL.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </Link>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from '@/utils/supabase/client';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { AppNavigation } from '@/components/app-navigation';
 
 /**
  * The login page for the application.
@@ -31,25 +32,34 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
-      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-        <div>
-          <Label htmlFor="email">Email</Label>
-          <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-        </div>
-        <div>
-          <Label htmlFor="password">Password</Label>
-          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-        </div>
-        {error && <p className="text-sm text-red-500">{error}</p>}
-        <Button type="submit" className="w-full">Sign In</Button>
-        <p className="text-center text-sm">
-          Need an account?{' '}
-          <Link href="/register" className="underline">
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation
+        endContent={(
+          <Link href="/register" className="text-sm font-medium text-primary underline-offset-4 hover:underline">
             Sign Up
           </Link>
-        </p>
-      </form>
+        )}
+      />
+      <main className="flex flex-1 items-center justify-center p-4">
+        <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+          </div>
+          <div>
+            <Label htmlFor="password">Password</Label>
+            <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <Button type="submit" className="w-full">Sign In</Button>
+          <p className="text-center text-sm">
+            Need an account?{' '}
+            <Link href="/register" className="underline">
+              Sign Up
+            </Link>
+          </p>
+        </form>
+      </main>
     </div>
   );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from '@/utils/supabase/client';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { AppNavigation } from '@/components/app-navigation';
 
 /**
  * The register page for the application.
@@ -31,39 +32,48 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
-      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-        <div>
-          <Label htmlFor="email">Email</Label>
-          <Input
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </div>
-        <div>
-          <Label htmlFor="password">Password</Label>
-          <Input
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </div>
-        {error && <p className="text-sm text-red-500">{error}</p>}
-        <Button type="submit" className="w-full">
-          Create Account
-        </Button>
-        <p className="text-center text-sm">
-          Already have an account?{' '}
-          <Link href="/login" className="underline">
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation
+        endContent={(
+          <Link href="/login" className="text-sm font-medium text-primary underline-offset-4 hover:underline">
             Sign In
           </Link>
-        </p>
-      </form>
+        )}
+      />
+      <main className="flex flex-1 items-center justify-center p-4">
+        <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <Button type="submit" className="w-full">
+            Create Account
+          </Button>
+          <p className="text-center text-sm">
+            Already have an account?{' '}
+            <Link href="/login" className="underline">
+              Sign In
+            </Link>
+          </p>
+        </form>
+      </main>
     </div>
   );
 }

--- a/src/components/app-navigation.tsx
+++ b/src/components/app-navigation.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ReactNode, useMemo } from 'react';
+
+import { cn } from '@/lib/utils';
+
+const NAV_LINKS = [
+  { href: '/', label: 'Dashboard' },
+  { href: '/integrations', label: 'Integrations' },
+  { href: '/matchup-report', label: 'Matchup Report' },
+];
+
+/**
+ * The top navigation used across application pages.
+ *
+ * @param startContent - Optional content rendered before the brand, e.g. sidebar triggers.
+ * @param endContent - Optional content rendered on the right side, e.g. page actions.
+ * @returns The application navigation header.
+ */
+export function AppNavigation({
+  startContent,
+  endContent,
+}: {
+  startContent?: ReactNode;
+  endContent?: ReactNode;
+}) {
+  const pathname = usePathname();
+
+  const highlightedLinks = useMemo(() => {
+    return NAV_LINKS.map((link) => {
+      const isHome = link.href === '/';
+      const isActive = isHome
+        ? pathname === '/'
+        : pathname.startsWith(link.href);
+
+      return {
+        ...link,
+        isActive,
+      };
+    });
+  }, [pathname]);
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur">
+      <div className="flex h-14 w-full items-center gap-4 px-4 sm:px-6">
+        <div className="flex flex-1 items-center gap-6">
+          <div className="flex items-center gap-2">
+            {startContent}
+            <Link href="/" className="text-base font-semibold tracking-tight">
+              Roster Loom
+            </Link>
+          </div>
+          <nav className="flex flex-wrap items-center gap-4 text-sm font-medium">
+            {highlightedLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-current={link.isActive ? 'page' : undefined}
+                className={cn(
+                  'transition-colors hover:text-primary',
+                  link.isActive ? 'text-primary' : 'text-muted-foreground'
+                )}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          {endContent}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -1,22 +1,13 @@
 'use client';
 
-import {
-  Sidebar,
-  SidebarHeader,
-  SidebarContent,
-  SidebarProvider,
-  SidebarInset,
-  SidebarTrigger,
-} from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
-import { Goal, PlusCircle, RefreshCw } from 'lucide-react';
-import Link from 'next/link';
+import { RefreshCw } from 'lucide-react';
 import { Team, Player, GroupedPlayer } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/utils/supabase/client';
-import { Badge } from "@/components/ui/badge";
+import { Badge } from '@/components/ui/badge';
 import { PlayerCard } from '@/components/player-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -125,55 +116,23 @@ function AppContent({
   };
 
   return (
-    <>
-      <Sidebar collapsible="icon">
-        <SidebarHeader className="p-4">
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation
+        endContent={(
           <div className="flex items-center gap-2">
-            <Button variant="ghost" size="icon" className="h-10 w-10 text-primary hover:bg-primary/10">
-              <Goal className="h-8 w-8" />
+            <Button
+              variant="outline"
+              onClick={handleRefreshClick}
+              disabled={isRefreshing}
+            >
+              <RefreshCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />
+              <span className="hidden sm:inline">Refresh</span>
             </Button>
-            <div className='group-data-[collapsible=icon]:hidden'>
-              <h1 className="text-xl font-semibold whitespace-nowrap">Roster Loom</h1>
-            </div>
+            <Button variant="outline" onClick={handleSignOutClick}>Sign Out</Button>
           </div>
-        </SidebarHeader>
-        <SidebarContent>
-            <div className='p-2'>
-                <Link href="/integrations">
-                  <Button variant="outline" className="w-full justify-start gap-2">
-                      <PlusCircle />
-                      <span className="group-data-[collapsible=icon]:hidden">Add League</span>
-                  </Button>
-                </Link>
-            </div>
-            <div className='p-2'>
-                <Link href="/matchup-report">
-                  <Button variant="outline" className="w-full justify-start gap-2">
-                      <PlusCircle />
-                      <span className="group-data-[collapsible=icon]:hidden">Matchup Report</span>
-                  </Button>
-                </Link>
-            </div>
-        </SidebarContent>
-      </Sidebar>
-      <SidebarInset>
-        <AppNavigation
-          startContent={<SidebarTrigger />}
-          endContent={(
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                onClick={handleRefreshClick}
-                disabled={isRefreshing}
-              >
-                <RefreshCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />
-                <span className="hidden sm:inline">Refresh</span>
-              </Button>
-              <Button variant="outline" onClick={handleSignOutClick}>Sign Out</Button>
-            </div>
-          )}
-        />
-        <div className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8 space-y-8">
+        )}
+      />
+      <main className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8 space-y-8">
           <h1 className="text-2xl font-semibold tracking-tight">Matchup Overview</h1>
           {refreshError && (
             <Alert variant="destructive">
@@ -276,9 +235,8 @@ function AppContent({
                     </CardContent>
                 </Card>
             </div>
-        </div>
-      </SidebarInset>
-    </>
+      </main>
+    </div>
   )
 }
 
@@ -343,14 +301,12 @@ export default function HomePage({ teams, user }: { teams: Team[], user: any }) 
   };
 
   return (
-    <SidebarProvider>
-      <AppContent
-        onSignOut={handleSignOut}
-        teams={currentTeams}
-        onRefresh={handleRefresh}
-        isRefreshing={isRefreshing}
-        refreshError={refreshError}
-      />
-    </SidebarProvider>
+    <AppContent
+      onSignOut={handleSignOut}
+      teams={currentTeams}
+      onRefresh={handleRefresh}
+      isRefreshing={isRefreshing}
+      refreshError={refreshError}
+    />
   );
 }

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { PlayerCard } from '@/components/player-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AppNavigation } from '@/components/app-navigation';
 
 /**
  * Groups a list of players by their position.
@@ -156,11 +157,9 @@ function AppContent({
         </SidebarContent>
       </Sidebar>
       <SidebarInset>
-        <header className={cn("sticky top-0 z-10 flex h-14 items-center gap-4 border-b bg-background/80 px-4 backdrop-blur-sm md:px-6")}>
-            <SidebarTrigger />
-            <div className="flex-1">
-                <h2 className="text-xl font-semibold">Matchup Overview</h2>
-            </div>
+        <AppNavigation
+          startContent={<SidebarTrigger />}
+          endContent={(
             <div className="flex items-center gap-2">
               <Button
                 variant="outline"
@@ -172,15 +171,17 @@ function AppContent({
               </Button>
               <Button variant="outline" onClick={handleSignOutClick}>Sign Out</Button>
             </div>
-        </header>
-        <main className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8 space-y-8">
-             {refreshError && (
-               <Alert variant="destructive">
-                 <AlertTitle>Refresh failed</AlertTitle>
-                 <AlertDescription>{refreshError}</AlertDescription>
-               </Alert>
-             )}
-             <Card>
+          )}
+        />
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8 space-y-8">
+          <h1 className="text-2xl font-semibold tracking-tight">Matchup Overview</h1>
+          {refreshError && (
+            <Alert variant="destructive">
+              <AlertTitle>Refresh failed</AlertTitle>
+              <AlertDescription>{refreshError}</AlertDescription>
+            </Alert>
+          )}
+          <Card>
                 <CardHeader>
                     <CardTitle>Weekly Matchups</CardTitle>
                 </CardHeader>
@@ -275,7 +276,7 @@ function AppContent({
                     </CardContent>
                 </Card>
             </div>
-        </main>
+        </div>
       </SidebarInset>
     </>
   )


### PR DESCRIPTION
## Summary
- add a reusable `AppNavigation` component with primary links for moving between app sections
- integrate the shared navigation across the dashboard, matchup report, integrations, and auth pages
- update the dashboard header to expose refresh/sign-out actions inside the shared navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cca46e892c832eb70f0f844019be35