### PR TITLE
Add navigation skeleton to loading screen

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,4 +1,6 @@
 import { Loader2 } from 'lucide-react';
+import { AppNavigation } from '@/components/app-navigation';
+import { Skeleton } from '@/components/ui/skeleton';
 
 /**
  * Loading treatment shown while the home page is generated on the server.
@@ -6,12 +8,22 @@ import { Loader2 } from 'lucide-react';
  */
 export default function Loading() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center">
-      <div className="flex flex-col items-center gap-4" role="status" aria-live="polite">
-        <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" aria-hidden="true" />
-        <p className="text-sm text-muted-foreground">Loading your dashboard&hellip;</p>
-        <span className="sr-only">Loading dashboard content</span>
-      </div>
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation
+        endContent={(
+          <div className="flex items-center gap-2">
+            <Skeleton className="hidden h-9 w-20 sm:inline" aria-hidden="true" />
+            <Skeleton className="h-9 w-24" aria-hidden="true" />
+          </div>
+        )}
+      />
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-12 sm:px-6">
+        <div className="flex flex-col items-center gap-4" role="status" aria-live="polite">
+          <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">Loading your dashboard&hellip;</p>
+          <span className="sr-only">Loading dashboard content</span>
+        </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- render the shared AppNavigation component on the home loading state
- show skeleton placeholders for the header actions while data is fetched
- keep the loading indicator centered beneath the navigation bar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccab52e43c832eb3f501224d10c71f