### PR TITLE
Filter bench matchup indicators

### DIFF
--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -65,6 +65,19 @@ function AppContent({
 }) {
   const colors = ['#f87171', '#60a5fa', '#facc15', '#4ade80', '#a78bfa', '#f472b6'];
 
+  const addMatchupColor = (
+    matchupColors: GroupedPlayer['matchupColors'],
+    color: string,
+    onBench: boolean
+  ) => {
+    const existingMatchup = matchupColors.find((matchup) => matchup.color === color);
+    if (existingMatchup) {
+      existingMatchup.onBench = existingMatchup.onBench && onBench;
+    } else {
+      matchupColors.push({ color, onBench });
+    }
+  };
+
   const groupPlayers = (
     players: Player[],
     existingPlayers: Map<string, GroupedPlayer>,
@@ -76,11 +89,13 @@ function AppContent({
         if (existingPlayers.has(key)) {
           const existingPlayer = existingPlayers.get(key)!;
           existingPlayer.count++;
-          if (!existingPlayer.matchupColors.includes(color)) {
-            existingPlayer.matchupColors.push(color);
-          }
+          addMatchupColor(existingPlayer.matchupColors, color, player.onBench);
         } else {
-          existingPlayers.set(key, { ...player, count: 1, matchupColors: [color] });
+          existingPlayers.set(key, {
+            ...player,
+            count: 1,
+            matchupColors: [{ color, onBench: player.onBench }],
+          });
         }
       }
     });

--- a/src/components/player-card.test.tsx
+++ b/src/components/player-card.test.tsx
@@ -19,7 +19,7 @@ describe('PlayerCard', () => {
     },
     imageUrl: 'https://example.com/player.jpg',
     onBench: false,
-    matchupColors: ['#000000'],
+    matchupColors: [{ color: '#000000', onBench: false }],
     count: 1,
   }
 

--- a/src/components/player-card.tsx
+++ b/src/components/player-card.tsx
@@ -14,6 +14,10 @@ import { Badge } from "@/components/ui/badge";
  * @returns A card that displays information about a player.
  */
 export function PlayerCard({ player }: { player: GroupedPlayer }) {
+    const matchupColors = player.onBench
+        ? player.matchupColors
+        : player.matchupColors.filter((matchup) => !matchup.onBench);
+
     return (
         <TooltipProvider>
             <Card className={cn(
@@ -26,8 +30,12 @@ export function PlayerCard({ player }: { player: GroupedPlayer }) {
                         <p className="text-xs sm:text-sm font-semibold leading-tight">{player.name}</p>
                         {player.onBench && <Badge variant="secondary">BN</Badge>}
                         <div className="flex items-center gap-1">
-                            {player.matchupColors.map((color, index) => (
-                                <div key={index} className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
+                            {matchupColors.map((matchup, index) => (
+                                <div
+                                    key={`${matchup.color}-${index}`}
+                                    className="w-2 h-2 rounded-full"
+                                    style={{ backgroundColor: matchup.color }}
+                                />
                             ))}
                         </div>
                     </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,11 +64,18 @@ export type Player = {
 /**
  * Represents a player grouped across multiple teams.
  */
+export type PlayerMatchupColor = {
+  /** The color associated with the matchup. */
+  color: string;
+  /** Indicates whether the player is on the bench for this matchup. */
+  onBench: boolean;
+};
+
 export type GroupedPlayer = Player & {
   /** The number of teams the player belongs to. */
   count: number;
   /** The colors of the matchups this player is in. */
-  matchupColors: string[];
+  matchupColors: PlayerMatchupColor[];
 };
 
 /**


### PR DESCRIPTION
## Summary
- track whether a grouped player was benched for each matchup color when aggregating rosters
- filter bench-only matchup dots from starter player cards while keeping bench dots intact
- update typings and tests to cover the new matchup color metadata

## Testing
- npm run test -- player-card

------
https://chatgpt.com/codex/tasks/task_e_68ccb1d36938832e8af19f157923bd73