### PR TITLE
Add navigation header to integration detail pages

### DIFF
--- a/src/app/integrations/ottoneu/page.tsx
+++ b/src/app/integrations/ottoneu/page.tsx
@@ -9,6 +9,7 @@ import {
   getOttoneuTeamInfo,
   getOttoneuLeagueTeams,
 } from './actions';
+import { AppNavigation } from '@/components/app-navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -183,85 +184,93 @@ export default function OttoneuPage() {
   };
 
   if (isLoadingIntegration) {
-    return <main className="p-4">Loading integration...</main>;
+    return (
+      <div className="flex min-h-screen flex-col">
+        <AppNavigation />
+        <main className="flex-1 p-4 sm:p-6 md:p-8">Loading integration...</main>
+      </div>
+    );
   }
 
   return (
-    <main className="p-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Ottoneu</CardTitle>
-          <CardDescription>
-            {integration
-              ? `Connected to ${teamName || 'your team'} in ${leagueName || 'your league'}`
-              : 'Enter your league URL and select your team to connect.'}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {!integration ? (
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <Label htmlFor="league-url">League URL</Label>
-                <Input
-                  id="league-url"
-                  type="url"
-                  value={leagueUrl}
-                  onChange={(e) => setLeagueUrl(e.target.value)}
-                  required
-                />
-              </div>
-              <div>
-                <Label htmlFor="team-name">Team Name</Label>
-                <Select
-                  value={teamQuery}
-                  onValueChange={(value) => {
-                    setTeamQuery(value);
-                    setError(null);
-                  }}
-                  disabled={isLoadingTeams || teamOptions.length === 0}
-                >
-                  <SelectTrigger id="team-name">
-                    <SelectValue
-                      placeholder={
-                        isLoadingTeams
-                          ? 'Loading teams...'
-                          : teamOptions.length > 0
-                            ? 'Select a team'
-                            : 'Enter a league URL to load teams'
-                      }
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {teamOptions.map((team) => (
-                      <SelectItem key={team} value={team}>
-                        {team}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {teamOptionsError && (
-                  <p className="mt-2 text-sm text-red-500">{teamOptionsError}</p>
-                )}
-              </div>
-              <Button type="submit" disabled={!teamQuery || isLoadingTeams}>
-                Connect
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex-1 p-4 sm:p-6 md:p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Ottoneu</CardTitle>
+            <CardDescription>
+              {integration
+                ? `Connected to ${teamName || 'your team'} in ${leagueName || 'your league'}`
+                : 'Enter your league URL and select your team to connect.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {!integration ? (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <Label htmlFor="league-url">League URL</Label>
+                  <Input
+                    id="league-url"
+                    type="url"
+                    value={leagueUrl}
+                    onChange={(e) => setLeagueUrl(e.target.value)}
+                    required
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="team-name">Team Name</Label>
+                  <Select
+                    value={teamQuery}
+                    onValueChange={(value) => {
+                      setTeamQuery(value);
+                      setError(null);
+                    }}
+                    disabled={isLoadingTeams || teamOptions.length === 0}
+                  >
+                    <SelectTrigger id="team-name">
+                      <SelectValue
+                        placeholder={
+                          isLoadingTeams
+                            ? 'Loading teams...'
+                            : teamOptions.length > 0
+                              ? 'Select a team'
+                              : 'Enter a league URL to load teams'
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {teamOptions.map((team) => (
+                        <SelectItem key={team} value={team}>
+                          {team}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {teamOptionsError && (
+                    <p className="mt-2 text-sm text-red-500">{teamOptionsError}</p>
+                  )}
+                </div>
+                <Button type="submit" disabled={!teamQuery || isLoadingTeams}>
+                  Connect
+                </Button>
+              </form>
+            ) : (
+              <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
+                {isRemoving ? 'Removing...' : 'Remove Integration'}
               </Button>
-            </form>
-          ) : (
-            <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
-              {isRemoving ? 'Removing...' : 'Remove Integration'}
-            </Button>
-          )}
-          {matchup && (
-            <div className="mt-4 text-sm">
-              <p>Week {matchup.week} vs {matchup.opponentName}</p>
-              <p className="font-semibold">{matchup.teamScore.toFixed(2)} - {matchup.opponentScore.toFixed(2)}</p>
-            </div>
-          )}
-          {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
-        </CardContent>
-      </Card>
-    </main>
+            )}
+            {matchup && (
+              <div className="mt-4 text-sm">
+                <p>Week {matchup.week} vs {matchup.opponentName}</p>
+                <p className="font-semibold">{matchup.teamScore.toFixed(2)} - {matchup.opponentScore.toFixed(2)}</p>
+              </div>
+            )}
+            {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
   );
 }
 

--- a/src/app/integrations/sleeper/page.tsx
+++ b/src/app/integrations/sleeper/page.tsx
@@ -9,6 +9,7 @@ import {
   removeSleeperIntegration,
   getLeagueMatchups,
 } from './actions';
+import { AppNavigation } from '@/components/app-navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -126,7 +127,12 @@ export default function SleeperPage() {
   }, [selectedLeague, selectedWeek]);
 
   if (loading) {
-    return <main className="p-4">Loading...</main>;
+    return (
+      <div className="flex min-h-screen flex-col">
+        <AppNavigation />
+        <main className="flex-1 p-4 sm:p-6 md:p-8">Loading...</main>
+      </div>
+    );
   }
 
   const groupedMatchups = matchups.reduce<Record<number, SleeperEnrichedMatchup[]>>((acc, matchup) => {
@@ -139,136 +145,139 @@ export default function SleeperPage() {
   }, {});
 
   return (
-    <main className="p-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Connect to Sleeper</CardTitle>
-          <CardDescription>
-            {integration
-              ? `Connected as ${integration.provider_user_id}.`
-              : "Enter your Sleeper username to connect your account."}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {!integration ? (
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <Label htmlFor="username">Sleeper Username</Label>
-                <Input
-                  id="username"
-                  type="text"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  required
-                />
-              </div>
-              <Button type="submit">Connect</Button>
-            </form>
-          ) : (
-            <div>
-              <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
-                {isRemoving ? 'Removing...' : 'Remove Integration'}
-              </Button>
-            </div>
-          )}
-          {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
-        </CardContent>
-      </Card>
-
-      {integration && leagues.length > 0 && (
-        <Card className="mt-4">
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex-1 p-4 sm:p-6 md:p-8">
+        <Card>
           <CardHeader>
-            <CardTitle>Your Leagues</CardTitle>
+            <CardTitle>Connect to Sleeper</CardTitle>
+            <CardDescription>
+              {integration
+                ? `Connected as ${integration.provider_user_id}.`
+                : "Enter your Sleeper username to connect your account."}
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="flex flex-wrap gap-2">
-              {leagues.map((league) => (
-                <Button
-                  key={league.league_id}
-                  onClick={() => setSelectedLeague(league)}
-                  variant={selectedLeague?.league_id === league.league_id ? 'default' : 'outline'}
-                >
-                  {league.name}
-                </Button>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {selectedLeague && (
-        <Card className="mt-4">
-          <CardHeader>
-            <CardTitle>Matchups for {selectedLeague.name}</CardTitle>
-            <div className="flex items-center space-x-2">
-              <Label htmlFor="week-selector">Week:</Label>
-              <Select value={selectedWeek} onValueChange={setSelectedWeek}>
-                <SelectTrigger id="week-selector" className="w-[180px]">
-                  <SelectValue placeholder="Select a week" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Array.from({ length: 18 }, (_, i) => i + 1).map((week) => (
-                    <SelectItem key={week} value={String(week)}>
-                      Week {week}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {loadingMatchups ? (
-              <p>Loading matchups...</p>
+            {!integration ? (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <Label htmlFor="username">Sleeper Username</Label>
+                  <Input
+                    id="username"
+                    type="text"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    required
+                  />
+                </div>
+                <Button type="submit">Connect</Button>
+              </form>
             ) : (
-              <div className="space-y-4">
-                {Object.values(groupedMatchups).map((matchupPair, index) => (
-                  <div key={index} className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    {matchupPair.map((team) => (
-                      <Card key={team.roster_id}>
-                        <CardHeader className="flex flex-row items-center justify-between">
-                          <div className="flex items-center space-x-2">
-                            <Image
-                              src={team.user.avatar ? `https://sleepercdn.com/avatars/thumbs/${team.user.avatar}` : 'https://via.placeholder.com/40'}
-                              alt={team.user.display_name}
-                              width={40}
-                              height={40}
-                              className="rounded-full"
-                            />
-                            <CardTitle>{team.user.display_name}</CardTitle>
-                          </div>
-                          <div className="text-2xl font-bold">{team.total_points.toFixed(2)}</div>
-                        </CardHeader>
-                        <CardContent>
-                          <Table>
-                            <TableHeader>
-                              <TableRow>
-                                <TableHead>Player</TableHead>
-                                <TableHead>Position</TableHead>
-                                <TableHead>Team</TableHead>
-                                <TableHead className="text-right">Score</TableHead>
-                              </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                              {team.players.map((player: SleeperMatchupPlayer) => (
-                                <TableRow key={player.player_id}>
-                                  <TableCell>{player.first_name} {player.last_name}</TableCell>
-                                  <TableCell>{player.position}</TableCell>
-                                  <TableCell>{player.team}</TableCell>
-                                  <TableCell className="text-right">{(player.score || 0).toFixed(2)}</TableCell>
-                                </TableRow>
-                              ))}
-                            </TableBody>
-                          </Table>
-                        </CardContent>
-                      </Card>
-                    ))}
-                  </div>
-                ))}
+              <div>
+                <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
+                  {isRemoving ? 'Removing...' : 'Remove Integration'}
+                </Button>
               </div>
             )}
+            {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
           </CardContent>
         </Card>
-      )}
-    </main>
+
+        {integration && leagues.length > 0 && (
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle>Your Leagues</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                {leagues.map((league) => (
+                  <Button
+                    key={league.league_id}
+                    onClick={() => setSelectedLeague(league)}
+                    variant={selectedLeague?.league_id === league.league_id ? 'default' : 'outline'}
+                  >
+                    {league.name}
+                  </Button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {selectedLeague && (
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle>Matchups for {selectedLeague.name}</CardTitle>
+              <div className="flex items-center space-x-2">
+                <Label htmlFor="week-selector">Week:</Label>
+                <Select value={selectedWeek} onValueChange={setSelectedWeek}>
+                  <SelectTrigger id="week-selector" className="w-[180px]">
+                    <SelectValue placeholder="Select a week" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Array.from({ length: 18 }, (_, i) => i + 1).map((week) => (
+                      <SelectItem key={week} value={String(week)}>
+                        Week {week}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {loadingMatchups ? (
+                <p>Loading matchups...</p>
+              ) : (
+                <div className="space-y-4">
+                  {Object.values(groupedMatchups).map((matchupPair, index) => (
+                    <div key={index} className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      {matchupPair.map((team) => (
+                        <Card key={team.roster_id}>
+                          <CardHeader className="flex flex-row items-center justify-between">
+                            <div className="flex items-center space-x-2">
+                              <Image
+                                src={team.user.avatar ? `https://sleepercdn.com/avatars/thumbs/${team.user.avatar}` : 'https://via.placeholder.com/40'}
+                                alt={team.user.display_name}
+                                width={40}
+                                height={40}
+                                className="rounded-full"
+                              />
+                              <CardTitle>{team.user.display_name}</CardTitle>
+                            </div>
+                            <div className="text-2xl font-bold">{team.total_points.toFixed(2)}</div>
+                          </CardHeader>
+                          <CardContent>
+                            <Table>
+                              <TableHeader>
+                                <TableRow>
+                                  <TableHead>Player</TableHead>
+                                  <TableHead>Position</TableHead>
+                                  <TableHead>Team</TableHead>
+                                  <TableHead className="text-right">Score</TableHead>
+                                </TableRow>
+                              </TableHeader>
+                              <TableBody>
+                                {team.players.map((player: SleeperMatchupPlayer) => (
+                                  <TableRow key={player.player_id}>
+                                    <TableCell>{player.first_name} {player.last_name}</TableCell>
+                                    <TableCell>{player.position}</TableCell>
+                                    <TableCell>{player.team}</TableCell>
+                                    <TableCell className="text-right">{(player.score || 0).toFixed(2)}</TableCell>
+                                  </TableRow>
+                                ))}
+                              </TableBody>
+                            </Table>
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </main>
+    </div>
   );
 }

--- a/src/app/integrations/yahoo/page.tsx
+++ b/src/app/integrations/yahoo/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { getYahooIntegration, getLeagues, removeYahooIntegration, getYahooLeagues, getYahooRoster, getYahooUserTeams, getTeams } from './actions';
+import { AppNavigation } from '@/components/app-navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -136,83 +137,91 @@ export default function YahooPage() {
   }, [integration]);
 
   if (loading) {
-    return <main className="p-4">Loading...</main>;
+    return (
+      <div className="flex min-h-screen flex-col">
+        <AppNavigation />
+        <main className="flex-1 p-4 sm:p-6 md:p-8">Loading...</main>
+      </div>
+    );
   }
 
   return (
-    <main className="p-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Connect to Yahoo</CardTitle>
-          <CardDescription>
-            {integration
-              ? "You have successfully connected your Yahoo account."
-              : "Click the button below to connect your Yahoo account."}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {!integration ? (
-            <Button onClick={handleConnect}>Connect Yahoo</Button>
-          ) : (
-            <div>
-              <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
-                {isRemoving ? 'Removing...' : 'Remove Integration'}
-              </Button>
-            </div>
-          )}
-          {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
-          {leagues.length > 0 && (
-            <div className="mt-4">
-              <h3 className="text-lg font-medium">Your Leagues</h3>
-              <ul className="mt-2 space-y-2">
-                {leagues.map((league) => (
-                  <li key={league.league_id} className="p-2 border rounded-md flex justify-between items-center">
-                    <span>{league.name}</span>
-                    <Button
-                      onClick={() => handleFetchRoster(league.league_id)}
-                      size="sm"
-                      disabled={loadingRosterLeagueId === league.league_id}
-                    >
-                      {loadingRosterLeagueId === league.league_id ? 'Loading...' : 'View Roster'}
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {players.length > 0 && (
-            <div className="mt-4">
-              <h3 className="text-lg font-medium">Roster</h3>
-              <ul className="mt-2 space-y-2">
-                {players.map((player) => (
-                  <li key={player.player_key} className="p-2 border rounded-md">
-                    {player.name} ({player.display_position})
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex-1 p-4 sm:p-6 md:p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Connect to Yahoo</CardTitle>
+            <CardDescription>
+              {integration
+                ? "You have successfully connected your Yahoo account."
+                : "Click the button below to connect your Yahoo account."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {!integration ? (
+              <Button onClick={handleConnect}>Connect Yahoo</Button>
+            ) : (
+              <div>
+                <Button onClick={handleRemove} disabled={isRemoving} variant="destructive">
+                  {isRemoving ? 'Removing...' : 'Remove Integration'}
+                </Button>
+              </div>
+            )}
+            {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+            {leagues.length > 0 && (
+              <div className="mt-4">
+                <h3 className="text-lg font-medium">Your Leagues</h3>
+                <ul className="mt-2 space-y-2">
+                  {leagues.map((league) => (
+                    <li key={league.league_id} className="flex items-center justify-between rounded-md border p-2">
+                      <span>{league.name}</span>
+                      <Button
+                        onClick={() => handleFetchRoster(league.league_id)}
+                        size="sm"
+                        disabled={loadingRosterLeagueId === league.league_id}
+                      >
+                        {loadingRosterLeagueId === league.league_id ? 'Loading...' : 'View Roster'}
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {players.length > 0 && (
+              <div className="mt-4">
+                <h3 className="text-lg font-medium">Roster</h3>
+                <ul className="mt-2 space-y-2">
+                  {players.map((player) => (
+                    <li key={player.player_key} className="rounded-md border p-2">
+                      {player.name} ({player.display_position})
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
-      <Card className="mt-4 bg-gray-800 text-white">
-        <CardHeader>
-          <CardTitle>Troubleshooting</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ul className="list-disc list-inside space-y-2">
-            <li>
-              If you see a &quot;Yahoo integration not found&quot; error, please try removing the integration and connecting again.
-            </li>
-            <li>
-              If your leagues or teams are not showing up, it might be because you don&apos;t have any active teams for the current NFL season in your Yahoo account.
-            </li>
-            <li>
-              The &quot;Could not find a team for this league&quot; error can happen if your team data is out of sync. Removing and re-adding the integration should resolve this.
-            </li>
-          </ul>
-        </CardContent>
-      </Card>
-    </main>
+        <Card className="mt-4 bg-gray-800 text-white">
+          <CardHeader>
+            <CardTitle>Troubleshooting</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="list-inside list-disc space-y-2">
+              <li>
+                If you see a &quot;Yahoo integration not found&quot; error, please try removing the integration and connecting again.
+              </li>
+              <li>
+                If your leagues or teams are not showing up, it might be because you don&apos;t have any active teams for the current NFL season in your Yahoo account.
+              </li>
+              <li>
+                The &quot;Could not find a team for this league&quot; error can happen if your team data is out of sync. Removing and re-adding the integration should resolve this.
+              </li>
+            </ul>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add the shared AppNavigation header to the Sleeper, Yahoo, and Ottoneu integration pages
- ensure loading states on these integration pages render the navigation with consistent spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb5425520832e868981222dc28a9a