### PR TITLE
Prevent duplicate Ottoneu team connections

### DIFF
--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -302,6 +302,27 @@ export async function connectOttoneu(
 
   const { teamName, leagueName, leagueId, teamId, matchup } = info;
 
+  const {
+    data: existingIntegration,
+    error: existingIntegrationError,
+  } = await supabase
+    .from('user_integrations')
+    .select('id')
+    .match({
+      user_id: user.id,
+      provider: 'ottoneu',
+      provider_user_id: teamId,
+    })
+    .single();
+
+  if (existingIntegrationError && existingIntegrationError.code !== 'PGRST116') {
+    return { error: existingIntegrationError.message };
+  }
+
+  if (existingIntegration) {
+    return { error: 'This Ottoneu team is already connected.' };
+  }
+
   const { data: integration, error: insertError } = await supabase
     .from('user_integrations')
     .insert({


### PR DESCRIPTION
## Summary
- prevent connecting the same Ottoneu team twice by checking for an existing integration before inserting
- expand the Ottoneu integration tests to cover the duplicate check and updated Supabase mocks

## Testing
- npm test -- src/app/integrations/ottoneu/actions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ccbe614514832e914acf63fdec8045