### PR TITLE
Treat Yahoo IR players as bench

### DIFF
--- a/src/app/integrations/yahoo/actions.test.ts
+++ b/src/app/integrations/yahoo/actions.test.ts
@@ -23,6 +23,19 @@ const rosterExample = {
                   { selected_position: [null, { position: 'QB' }] },
                 ],
               },
+              '1': {
+                player: [
+                  [
+                    { player_key: 'p4' },
+                    { player_id: 'p4' },
+                    { name: { full: 'Yahoo Player 2' } },
+                    { display_position: 'RB' },
+                    { headshot: { url: '' } },
+                    { editorial_team_abbr: 'DAL' },
+                  ],
+                  { selected_position: [null, { position: 'IR' }] },
+                ],
+              },
             },
           },
         },
@@ -123,6 +136,10 @@ describe('yahoo actions', () => {
       player_key: 'p3',
       name: 'Yahoo Player 1',
       display_position: 'QB',
+      onBench: false,
     });
+
+    const irPlayer = result.players.find((player: any) => player.player_key === 'p4');
+    expect(irPlayer).toMatchObject({ onBench: true });
   });
 });

--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -485,6 +485,13 @@ export async function getYahooRoster(integrationId: number, leagueId: string, te
       });
 
       const selectedPosition = playerInfo.selected_position?.[1]?.position;
+      const normalizedPosition =
+        typeof selectedPosition === 'string'
+          ? selectedPosition.trim().toUpperCase()
+          : '';
+      const isBench =
+        normalizedPosition === 'BN' ||
+        normalizedPosition.startsWith('IR');
 
       return {
         player_key: playerDetails.player_key,
@@ -502,7 +509,7 @@ export async function getYahooRoster(integrationId: number, leagueId: string, te
         is_undroppable: playerDetails.is_undroppable,
         position_type: playerDetails.position_type,
         eligible_positions: playerDetails.eligible_positions?.map((pos: any) => pos.position),
-        onBench: selectedPosition === 'BN',
+        onBench: isBench,
       };
     }).filter(Boolean); // Filter out any null entries from failed parsing
 


### PR DESCRIPTION
## Summary
- normalize Yahoo roster slot parsing so IR slots are considered bench players
- extend Yahoo roster parsing test coverage to include an IR example

## Testing
- npm test -- src/app/integrations/yahoo/actions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ccbe912764832ea09904161fa1db06