### PR TITLE
Prefetch Yahoo user score data when building teams

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -689,6 +689,13 @@ export async function buildYahooTeams(
   };
 
   const buildTeam = async (team: any): Promise<Team | null> => {
+    const userPlayerScoresPromise = getYahooPlayerScores(
+      integration.id,
+      team.team_key,
+      resolvedAccessToken,
+      resolvedWeek
+    );
+
     const { matchups, error: matchupsError } = await getYahooMatchups(
       integration.id,
       team.team_key,
@@ -697,6 +704,7 @@ export async function buildYahooTeams(
     );
 
     if (matchupsError || !matchups) {
+      await Promise.allSettled([userPlayerScoresPromise]);
       return null;
     }
 
@@ -729,19 +737,16 @@ export async function buildYahooTeams(
       return null;
     }
 
+    const opponentPlayerScoresPromise = getYahooPlayerScores(
+      integration.id,
+      opponentTeam.team_key,
+      resolvedAccessToken,
+      resolvedWeek
+    );
+
     const [userScoresResult, opponentScoresResult] = await Promise.allSettled([
-      getYahooPlayerScores(
-        integration.id,
-        userTeam.team_key,
-        resolvedAccessToken,
-        resolvedWeek
-      ),
-      getYahooPlayerScores(
-        integration.id,
-        opponentTeam.team_key,
-        resolvedAccessToken,
-        resolvedWeek
-      ),
+      userPlayerScoresPromise,
+      opponentPlayerScoresPromise,
     ]);
 
     let userPlayerScores: any[] | null | undefined;


### PR DESCRIPTION
## Summary
- start the Yahoo user player score request as soon as the access token and week are known so it can run in parallel with matchup loading
- reuse the pre-started user score promise, pair it with the opponent stats fetch, and retain the existing error handling when mapping rosters

## Testing
- npm test -- src/app/integrations/yahoo/actions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdf2fdb000832eac51842fa03b5d24