### PR TITLE
Enrich Yahoo player scores with roster metadata

### DIFF
--- a/src/app/integrations/yahoo/actions.test.ts
+++ b/src/app/integrations/yahoo/actions.test.ts
@@ -115,7 +115,16 @@ describe('yahoo actions', () => {
       player_key: '461.p.40896',
       name: 'Jayden Daniels',
       totalPoints: '19.70',
+      display_position: 'QB',
+      editorial_team_abbr: 'Was',
+      selected_position: 'QB',
+      onBench: false,
     });
+
+    const benchPlayer = result.players.find(
+      (player: any) => player.selected_position === 'BN'
+    );
+    expect(benchPlayer?.onBench).toBe(true);
   });
 
   it('parses roster correctly', async () => {


### PR DESCRIPTION
## Summary
- populate Yahoo player score results with roster metadata and bench flags via the stats response
- refactor Yahoo team building to consume the enriched score data and streamline tests around error handling

## Testing
- npm test -- src/app/actions.test.ts src/app/integrations/yahoo/actions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdf4d68c6c832e8470162d5946b3c3