### PR TITLE
Show game time remaining on live player cards

### DIFF
--- a/src/components/player-card.test.tsx
+++ b/src/components/player-card.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { PlayerCard, getGameStatusLabel } from '@/components/player-card'
+import { PlayerCard, getGameStatusLabel, getGamePercentRemaining } from '@/components/player-card'
 import type { GroupedPlayer } from '@/lib/types'
 
 describe('PlayerCard', () => {
@@ -62,6 +62,59 @@ describe('PlayerCard', () => {
     }
 
     render(<PlayerCard player={livePlayer} />)
-    expect(screen.getByText('Q3 4:12')).toBeInTheDocument()
+    expect(screen.getByText('Q3 4:12 • 32% remaining')).toBeInTheDocument()
+  })
+
+  it('shows the percentage remaining for a live game', () => {
+    const livePlayer = {
+      ...player,
+      gameStatus: 'in_progress',
+      gameQuarter: 'Q1',
+      gameClock: '10:00',
+    }
+
+    render(<PlayerCard player={livePlayer} />)
+    expect(screen.getByText(/92% remaining/)).toBeInTheDocument()
+  })
+})
+
+describe('getGamePercentRemaining', () => {
+  const basePlayer: GroupedPlayer = {
+    id: '1',
+    name: 'Test Player',
+    position: 'QB',
+    realTeam: 'TB',
+    score: 0,
+    gameStatus: 'in_progress',
+    gameStartTime: null,
+    gameQuarter: 'Q2',
+    gameClock: '12:30',
+    onUserTeams: 0,
+    onOpponentTeams: 0,
+    gameDetails: {
+      score: '',
+      timeRemaining: '',
+      fieldPosition: '',
+    },
+    imageUrl: '',
+    onBench: false,
+    matchupColors: [],
+    count: 1,
+  }
+
+  it('calculates the remaining percentage for a valid in-progress game', () => {
+    const result = getGamePercentRemaining(basePlayer)
+    expect(result).not.toBeNull()
+    expect(result as number).toBeCloseTo(70.8, 1)
+  })
+
+  it('returns null when the game is not in progress', () => {
+    const result = getGamePercentRemaining({ ...basePlayer, gameStatus: 'final' })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the quarter is missing', () => {
+    const result = getGamePercentRemaining({ ...basePlayer, gameQuarter: null })
+    expect(result).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- calculate the percentage of regulation time remaining for in-progress games
- render the remaining percentage next to the live status on player cards
- add tests for the new helper and updated player card display

## Testing
- npm test -- player-card

------
https://chatgpt.com/codex/tasks/task_e_68d030ecbfe4832e8b71ffdbacbc7db9