### PR TITLE
Add overlay to represent game progress on player cards

### DIFF
--- a/src/components/player-card.test.tsx
+++ b/src/components/player-card.test.tsx
@@ -80,6 +80,38 @@ describe('PlayerCard', () => {
     const overlay = screen.getByTestId('game-progress-overlay')
     expect(overlay).toHaveStyle(`height: ${expectedHeight}%`)
   })
+
+  it.each([
+    {
+      description: 'more than 25% remaining',
+      gameQuarter: 'Q3' as const,
+      gameClock: '10:00',
+      expectedClass: 'bg-emerald-500/20',
+    },
+    {
+      description: '25% or less remaining',
+      gameQuarter: 'Q4' as const,
+      gameClock: '15:00',
+      expectedClass: 'bg-yellow-400/20',
+    },
+    {
+      description: '10% or less remaining',
+      gameQuarter: 'Q4' as const,
+      gameClock: '6:00',
+      expectedClass: 'bg-red-500/20',
+    },
+  ])('uses $description overlay color', ({ gameQuarter, gameClock, expectedClass }) => {
+    const livePlayer = {
+      ...player,
+      gameStatus: 'in_progress' as const,
+      gameQuarter,
+      gameClock,
+    }
+
+    render(<PlayerCard player={livePlayer} />)
+    const overlay = screen.getByTestId('game-progress-overlay')
+    expect(overlay).toHaveClass(expectedClass)
+  })
 })
 
 describe('getGamePercentRemaining', () => {

--- a/src/components/player-card.tsx
+++ b/src/components/player-card.tsx
@@ -105,6 +105,17 @@ export function PlayerCard({ player }: { player: GroupedPlayer }) {
         : player.matchupColors.filter((matchup) => !matchup.onBench);
     const statusLabel = getGameStatusLabel(player);
     const gamePercentRemaining = getGamePercentRemaining(player);
+    const progressOverlayClassName =
+        typeof gamePercentRemaining === 'number'
+            ? cn(
+                  'absolute inset-x-0 bottom-0',
+                  gamePercentRemaining <= 10
+                      ? 'bg-red-500/20'
+                      : gamePercentRemaining <= 25
+                        ? 'bg-yellow-400/20'
+                        : 'bg-emerald-500/20'
+              )
+            : null;
 
     return (
         <TooltipProvider>
@@ -114,11 +125,11 @@ export function PlayerCard({ player }: { player: GroupedPlayer }) {
                     { "opacity-50": player.onBench }
                 )}
             >
-                {typeof gamePercentRemaining === 'number' && (
+                {typeof gamePercentRemaining === 'number' && progressOverlayClassName && (
                     <div
                         aria-hidden="true"
                         data-testid="game-progress-overlay"
-                        className="absolute inset-x-0 bottom-0 bg-emerald-500/20"
+                        className={progressOverlayClassName}
                         style={{ height: `${gamePercentRemaining}%` }}
                     />
                 )}


### PR DESCRIPTION
## Summary
- replace the textual game progress indicator with a green overlay on the player card
- ensure the overlay height corresponds to the remaining game percentage while keeping existing card content intact
- update unit tests to validate the overlay rendering and retain other player card behaviors

## Testing
- npm test -- player-card

------
https://chatgpt.com/codex/tasks/task_e_68d034cd0260832ea76959c35a6ea5c4