### PR TITLE
Add celebratory score animation on refresh

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,3 +86,42 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes score-celebration {
+  0% {
+    transform: scale(1) rotate(0deg);
+    text-shadow: none;
+    filter: none;
+  }
+  25% {
+    transform: scale(1.35) rotate(-6deg);
+    text-shadow: 0 0 12px rgba(236, 72, 153, 0.9), 0 0 20px rgba(250, 204, 21, 0.8);
+    filter: hue-rotate(25deg) saturate(180%);
+  }
+  45% {
+    transform: scale(0.9) rotate(4deg);
+    text-shadow: 0 0 18px rgba(59, 130, 246, 0.85);
+    filter: hue-rotate(-20deg) saturate(160%);
+  }
+  65% {
+    transform: scale(1.28) rotate(-3deg);
+    text-shadow: 0 0 22px rgba(16, 185, 129, 0.9), 0 0 30px rgba(244, 114, 182, 0.85);
+    filter: hue-rotate(10deg) saturate(210%);
+  }
+  85% {
+    transform: scale(1.12) rotate(2deg);
+    text-shadow: 0 0 14px rgba(251, 191, 36, 0.75);
+    filter: hue-rotate(-12deg) saturate(150%);
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    text-shadow: none;
+    filter: none;
+  }
+}
+
+.score-celebrate {
+  animation: score-celebration 1.4s ease-out;
+  animation-fill-mode: both;
+  will-change: transform, filter;
+}

--- a/src/components/player-card.tsx
+++ b/src/components/player-card.tsx
@@ -97,9 +97,10 @@ export function getGamePercentRemaining(player: GroupedPlayer): number | null {
 /**
  * A card that displays information about a player.
  * @param player - The player to display.
+ * @param isScoreChanged - Indicates whether the player's score changed during the last refresh.
  * @returns A card that displays information about a player.
  */
-export function PlayerCard({ player }: { player: GroupedPlayer }) {
+export function PlayerCard({ player, isScoreChanged = false }: { player: GroupedPlayer; isScoreChanged?: boolean }) {
     const matchupColors = player.onBench
         ? player.matchupColors
         : player.matchupColors.filter((matchup) => !matchup.onBench);
@@ -184,7 +185,9 @@ export function PlayerCard({ player }: { player: GroupedPlayer }) {
                     </div>
                     <div className="text-right">
                         <p className="text-sm sm:text-base lg:text-xl font-bold text-foreground">
-                            {player.score.toFixed(1)}
+                            <span className={cn('inline-block', isScoreChanged && 'score-celebrate')}>
+                                {player.score.toFixed(1)}
+                            </span>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- detect score changes after a refresh and track changed team and player scores
- animate updated numbers for teams and player cards with a lively celebration effect
- add global animation styles and plumb change flags through the player card component

## Testing
- npm run lint
- npm test -- player-card

------
https://chatgpt.com/codex/tasks/task_e_68d046dc1100832eae529481a92215cd