### PR TITLE
Reorder navigation menu links

### DIFF
--- a/src/components/app-navigation.tsx
+++ b/src/components/app-navigation.tsx
@@ -11,8 +11,8 @@ import { cn } from '@/lib/utils';
 
 const NAV_LINKS = [
   { href: '/', label: 'Dashboard' },
-  { href: '/integrations', label: 'Integrations' },
   { href: '/matchup-report', label: 'Matchup Report' },
+  { href: '/integrations', label: 'Integrations' },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- reorder the top navigation links so Matchup Report appears before Integrations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d084fd7fcc832e9f8747e4662d7d86