### PR TITLE
chore: ignore .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ playwright-report/
 # next-pwa
 /public/sw.js
 /public/workbox-*.js
+
+# mcp (contains secrets)
+.mcp.json


### PR DESCRIPTION
## Summary
- Add `.mcp.json` to `.gitignore` since it can contain secrets and should not be committed.

## Test plan
- [x] Verify `.mcp.json` is ignored by git going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)