### PR TITLE
setup: harness engineering for AI coding agents

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,36 @@
+---
+description: Push the current branch and open a PR
+---
+
+Steps:
+
+1. Confirm you're not on `main` (PRs from `main` are not allowed):
+   ```bash
+   git rev-parse --abbrev-ref HEAD
+   ```
+2. Confirm the tree is clean (or commit outstanding changes first):
+   ```bash
+   git status
+   ```
+3. Push the branch and open the PR:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --fill
+   ```
+4. Return the PR URL printed by `gh`.
+
+If `--fill` produces a thin description, prefer:
+
+```bash
+gh pr create --title "<imperative summary>" --body "$(cat <<'EOF'
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+EOF
+)"
+```
+
+See [docs/GIT_WORKFLOW.md](../../docs/GIT_WORKFLOW.md) for branch
+naming and commit conventions.

--- a/.claude/commands/db-types.md
+++ b/.claude/commands/db-types.md
@@ -1,0 +1,21 @@
+---
+description: Regenerate Supabase TS types and the schema reference doc
+---
+
+Run after any change under `supabase/migrations/`.
+
+1. Make sure the local Supabase project is linked:
+   ```bash
+   npx supabase status
+   ```
+2. Regenerate TypeScript types:
+   ```bash
+   npx supabase gen types typescript --linked > src/lib/database.types.ts
+   ```
+3. Update the schema snapshot at
+   [docs/references/database-schema.md](../../docs/references/database-schema.md)
+   so agents reading the docs map see the new shape.
+4. Commit the regenerated files alongside the migration in the same PR.
+
+If `--linked` fails, the project isn't linked yet — use
+`npx supabase link --project-ref <ref>` first (ask the human for the ref).

--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -1,0 +1,35 @@
+---
+description: Retrospective — find friction and propose doc/skill updates
+---
+
+Review the current conversation and surface places the harness could be
+better. The goal is a tighter loop next time, not a postmortem.
+
+## Look for
+
+- **Agent errors or backtracking** — wrong assumptions, dead ends,
+  re-reading the same file repeatedly.
+- **User corrections** — anything the human had to point out that the
+  docs or skills should have prevented.
+- **Missing documentation** — facts you discovered the hard way that
+  aren't in `AGENTS.md`, `CLAUDE.md`, or `docs/`.
+- **Missing skills** — repetitive command sequences that should be a
+  one-liner under `.claude/commands/`.
+- **Approval gates that could be automated** — repeated permission
+  prompts where adding an allow rule to `.claude/settings.local.json`
+  would be safe.
+- **Stale rules** — guidance in the docs that no longer matches reality.
+
+## Output
+
+1. Present a table:
+
+   | Finding | Proposed fix | Where it lands |
+   | --- | --- | --- |
+
+2. Wait for the user to approve / reject each row.
+3. Implement approved changes.
+4. Open a single PR titled `chore: retro updates from <date>` with the
+   doc/skill changes. Follow [docs/GIT_WORKFLOW.md](../../docs/GIT_WORKFLOW.md).
+
+If nothing surfaced, say so plainly — don't manufacture findings.

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -1,0 +1,24 @@
+---
+description: Run the Jest unit test suite
+---
+
+Run the unit tests. **Do not run the e2e suite** — see
+[docs/TESTING.md](../../docs/TESTING.md) for why.
+
+```bash
+npm test
+```
+
+To target a single file or test name:
+
+```bash
+npm test -- src/app/actions.test.ts
+npm test -- -t "buildSleeperTeams"
+```
+
+After tests pass, also run lint and types before reporting success:
+
+```bash
+npm run lint
+npm run typecheck
+```

--- a/.claude/commands/start-dev.md
+++ b/.claude/commands/start-dev.md
@@ -1,0 +1,15 @@
+---
+description: Start the Next.js dev server on port 9002
+---
+
+Start the dev server (Turbopack, port **9002**, not 3000):
+
+```bash
+npm run dev
+```
+
+Open http://localhost:9002 to view the app.
+
+If the port is already in use, check whether a previous `npm run dev`
+is still attached to the terminal session before killing anything —
+Playwright reuses an existing server outside of CI.

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ playwright-report/
 # next-pwa
 /public/sw.js
 /public/workbox-*.js
+
+# Claude Code — user-local; team-shared skills live in .claude/commands/
+.claude/settings.local.json
+.mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,78 +1,91 @@
-# AGENTS
+# AGENTS.md
 
-This document provides instructions for agents on how to set up and run this project.
+Universal instructions for AI coding agents working on **Roster Loom**
+(repo: `alex-monroe/fantasy-pulse`).
 
-## Frontend Verification
+## Project Overview
 
-Skip the `frontend_verification` tool. Do not use it to verify frontend changes.
+A one-stop fantasy football scoreboard. Users connect Sleeper, Yahoo,
+and Ottoneu accounts; the app aggregates their teams and renders live
+matchup data with cross-team player-share indicators.
 
-## E2E Tests
+- **Tech stack:** Next.js 15.3.6 (App Router) · React 18 · TypeScript 5 · Tailwind 3 · Supabase (Postgres + Auth) · Jest 29 · Playwright 1.55
+- **Package manager:** **npm** (lockfile is committed; CI requires it in sync)
+- **Node:** **20.x** (from `.nvmrc` and `engines`)
+- **Dev port:** **9002** (not 3000)
 
-Do not run the e2e tests to validate behavior. They are not reliable.
+## Quick Reference
 
-## Test Credentials
-Use the following credentials for any login steps during automated tests:
+- **Commands:** [docs/COMMANDS.md](docs/COMMANDS.md) — every CLI command
+- **Architecture:** [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — stack, data flow, provider pattern
+- **Code layout:** [docs/CODE_ORGANIZATION.md](docs/CODE_ORGANIZATION.md) — where things live, module rules
+- **Testing:** [docs/TESTING.md](docs/TESTING.md) — Jest setup, why E2E is off-limits
+- **Git workflow:** [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) — branch + PR rules
+- **Add a provider:** [docs/adding-integrations.md](docs/adding-integrations.md)
+- **DB schema:** [docs/references/database-schema.md](docs/references/database-schema.md)
+- **Env vars:** [docs/references/environment.md](docs/references/environment.md)
 
-- Email: test@test.com
-- Password: test
+## Documentation Map
 
-## Database Schema
-
-```sql
--- WARNING: This schema is for context only and is not meant to be run.
--- Table order and constraints may not be valid for execution.
-
-CREATE TABLE public.leagues (
-  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  league_id text,
-  name character varying,
-  user_integration_id bigint,
-  season text,
-  total_rosters bigint,
-  status text,
-  user_id uuid DEFAULT auth.uid(),
-  CONSTRAINT leagues_pkey PRIMARY KEY (id),
-  CONSTRAINT leagues_user_integrations_id_fkey FOREIGN KEY (user_integration_id) REFERENCES public.user_integrations(id)
-);
-CREATE TABLE public.notes (
-  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  text text,
-  user_id uuid,
-  CONSTRAINT notes_pkey PRIMARY KEY (id)
-);
-CREATE TABLE public.user_integrations (
-  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  user_id uuid DEFAULT auth.uid(),
-  provider character varying,
-  provider_user_id text,
-  CONSTRAINT user_integrations_pkey PRIMARY KEY (id)
-);
+```
+AGENTS.md                          <- you are here (universal entry point)
+CLAUDE.md                          # Claude-Code-specific extensions
+CONTRIBUTING.md                    # Human contributor pointer (mostly defers here)
+docs/
+├── ARCHITECTURE.md                # System design, tech stack, data flow
+├── COMMANDS.md                    # All CLI commands grouped by domain
+├── CODE_ORGANIZATION.md           # File layout, module boundaries, conventions
+├── TESTING.md                     # Jest setup, E2E policy, CI signals
+├── GIT_WORKFLOW.md                # Branch + PR rules
+├── adding-integrations.md         # How to add a new fantasy provider
+├── blueprint.md                   # Original product brief (style + features)
+└── references/
+    ├── database-schema.md         # Snapshot of Supabase schema (regen after migrations)
+    └── environment.md             # Env var reference
 ```
 
-## Development
+Per-provider docs are colocated with their code under
+`src/app/integrations/<provider>/README.md`.
 
-### `package-lock.json` Synchronization
+## Code Style
 
-When making changes to dependencies in `package.json`, you must regenerate the `package-lock.json` file. This is crucial because our continuous integration (CI) pipeline uses the `npm ci` command, which requires `package.json` and `package-lock.json` to be perfectly in sync.
+- TypeScript everywhere. No new `.js` files in `src/`.
+- Server-only modules start with `'use server';` — keep client and
+  server boundaries explicit.
+- Tests are **colocated** as `<name>.test.ts(x)` next to implementation.
+- Tailwind for styling; reuse shadcn primitives in `src/components/ui/`
+  before hand-rolling.
+- Import via the `@/...` alias (mapped to `src/`).
+- Log structured data via `src/utils/logger.ts`; never `console.log` in
+  production paths.
 
-If they are not in sync, the CI pipeline will fail with an error similar to this:
-`npm ERR! clean install a project with an out-of-sync lockfile`
+## Architectural Rules
 
-To prevent this, after any change in `package.json`, run the following command to update `package-lock.json`:
+1. **Providers don't import providers.** `integrations/yahoo` may not
+   import from `integrations/sleeper`. Cross-provider work lives in
+   `src/app/actions.ts`.
+2. **Supabase access is centralized** in `src/utils/supabase/`
+   (`server.ts` for RSC/route handlers, `client.ts` for the browser).
+3. **External API calls are timed.** Wrap them with `startTimer` /
+   `logDuration` from `src/utils/performance-logger.ts`.
+4. **Schema changes happen via new SQL migrations** under
+   `supabase/migrations/`. Never edit a committed migration. Regenerate
+   `docs/references/database-schema.md` afterward.
+5. **Every new provider follows the five-file pattern**
+   (`actions.ts`, `actions.test.ts`, `page.tsx`, `README.md`,
+   `*.example.json`) — see [docs/adding-integrations.md](docs/adding-integrations.md).
 
-```bash
-npm install
-```
+## Critical Rules
 
-After running the command, be sure to commit the updated `package-lock.json` file along with your other changes. If you forget to do this, you will need to pull the latest changes, run `npm install`, and then push the updated `package-lock.json` file.
-
-## Yahoo Player Scores Example
-
-Use `src/app/integrations/yahoo/player-scores.example.json` as a reference when developing against the Yahoo player scores API.
-
-## Sleeper Matchups Example
-
-Use `src/app/integrations/sleeper/matchups.example.json` as a reference when developing or updating Sleeper matchup logic.
+- **Do not run `npm run test:e2e`.** Playwright tests are flaky and
+  CI-only; rely on the workflow comment posted on each PR.
+- **Skip `frontend_verification`** if your harness offers it — it's
+  unreliable here.
+- **After any `package.json` change, run `npm install`** and commit the
+  regenerated `package-lock.json` in the same commit; CI breaks otherwise.
+- **Never commit directly to `main`.** Branch off, push, open a PR with
+  `gh pr create`.
+- **Test credentials** for any login step: `test@test.com` / `test`.
+- **Update the docs map** when you add/rename files referenced from
+  `AGENTS.md` or `CLAUDE.md`. A Jest test enforces this — see
+  `src/lib/doc-map.test.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+Guidance for [Claude Code](https://claude.com/claude-code) working on
+**Roster Loom** (`alex-monroe/fantasy-pulse`). This file extends
+[AGENTS.md](AGENTS.md) with Claude-specific details.
+
+## Project Overview
+
+Roster Loom aggregates Sleeper, Yahoo, and Ottoneu fantasy football
+teams into a single live scoreboard. The home page fans out to
+1–3 external APIs per render, so performance discipline (batched fetches,
+token reuse, caching) matters more than feature volume.
+
+- **Tech stack:** Next.js 15.3.6 (App Router, Turbopack) · React 18 · TypeScript 5 · Tailwind 3 · Supabase · Jest 29 · Playwright 1.55
+- **Package manager:** `npm` — never use `pnpm` or `yarn` in this repo
+- **Node:** `nvm use` will pick **20.x** from `.nvmrc`
+- **Dev port:** **9002** (set in `package.json`; Playwright + Yahoo redirect URI assume it)
+
+## Quick Reference
+
+- **Commands:** [docs/COMMANDS.md](docs/COMMANDS.md)
+- **Architecture:** [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- **Code layout:** [docs/CODE_ORGANIZATION.md](docs/CODE_ORGANIZATION.md)
+- **Testing:** [docs/TESTING.md](docs/TESTING.md)
+- **Git workflow:** [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md)
+- **Add a provider:** [docs/adding-integrations.md](docs/adding-integrations.md)
+- **DB schema:** [docs/references/database-schema.md](docs/references/database-schema.md)
+- **Env vars:** [docs/references/environment.md](docs/references/environment.md)
+
+## Skills (`.claude/commands/`)
+
+- `/run-tests` — `npm test` (Jest only; e2e is off-limits)
+- `/start-dev` — `npm run dev` on port 9002
+- `/create-pr` — push current branch and open a PR with `gh`
+- `/db-types` — regenerate Supabase TS types and the schema reference
+- `/retro` — review the conversation for friction and propose doc/skill updates
+
+## MCP servers
+
+`.mcp.json` enables `supabase` and `github` MCP servers (gated by
+`.claude/settings.local.json`). Prefer the MCP tools over shelling
+out for those services when available.
+
+## Documentation Map
+
+```
+AGENTS.md                          # Universal entry point
+CLAUDE.md                          <- you are here
+CONTRIBUTING.md                    # Human contributor pointer
+.claude/commands/                  # Claude Code skills
+docs/
+├── ARCHITECTURE.md                # System design, tech stack, data flow
+├── COMMANDS.md                    # All CLI commands grouped by domain
+├── CODE_ORGANIZATION.md           # File layout, module boundaries
+├── TESTING.md                     # Jest setup, E2E policy, CI signals
+├── GIT_WORKFLOW.md                # Branch + PR rules
+├── adding-integrations.md         # How to add a new fantasy provider
+├── blueprint.md                   # Original product brief
+└── references/
+    ├── database-schema.md         # Supabase schema snapshot
+    └── environment.md             # Env var reference
+```
+
+## GitHub Repository
+
+- Owner / name: **`alex-monroe/fantasy-pulse`** (note: the user-facing
+  product name is "Roster Loom" but the repo is `fantasy-pulse`)
+- Default branch: `main`
+- CI: `.github/workflows/playwright.yml` runs on push + PR to `main`
+
+## Critical Rules
+
+- **Do not run `npm run test:e2e`.** Rely on the CI report linked from
+  the PR comment.
+- **Skip the `frontend_verification` tool** if your harness offers it.
+- **After any `package.json` change**, run `npm install` and commit the
+  regenerated `package-lock.json` in the same commit.
+- **Never commit directly to `main`.** Branch, push, `gh pr create`.
+- **Test credentials:** `test@test.com` / `test`.
+- **Update the docs map** when you add/rename files referenced from
+  `AGENTS.md` or `CLAUDE.md`. The Jest test in `src/lib/doc-map.test.ts`
+  will fail otherwise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,91 +1,29 @@
 # Contributing to Roster Loom
 
-First off, thank you for considering contributing to Roster Loom! It's people like you that make Roster Loom such a great tool.
+Thanks for your interest! Most of what you need lives in the docs.
 
-## Running the E2E Tests
+## For humans
 
-To run the end-to-end tests, follow these steps:
+- **Local setup, env vars, dev server:** see the [README](README.md)
+  and [docs/COMMANDS.md](docs/COMMANDS.md).
+- **How the codebase is laid out:** [docs/CODE_ORGANIZATION.md](docs/CODE_ORGANIZATION.md)
+- **Running tests:** [docs/TESTING.md](docs/TESTING.md)
+- **Branching and PRs:** [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md)
+- **Adding a new fantasy provider:** [docs/adding-integrations.md](docs/adding-integrations.md)
 
-1.  **Install dependencies:**
-    ```bash
-    npm install
-    ```
+## For AI coding agents
 
-2.  **Create the environment file:**
-    Create a `.env.local` file in the root of the project and add the necessary environment variables. You can use the `.env.example` file as a template.
+Start at [AGENTS.md](AGENTS.md) (universal) or [CLAUDE.md](CLAUDE.md)
+(Claude Code specific). Both are intentionally short maps that point to
+the docs above.
 
-3.  **Install Playwright browsers:**
-    ```bash
-    npx playwright install
-    ```
+## Test credentials
 
-4.  **Install Playwright dependencies:**
-    ```bash
-    npx playwright install-deps
-    ```
+For any login step in automated tests: `test@test.com` / `test`.
 
-5.  **Run the tests:**
-    ```bash
-    npm run test:e2e
-    ```
+## `package-lock.json`
 
-## Test Credentials
-Use the following credentials for any login steps during automated tests:
-
-- Email: test@test.com
-- Password: test
-
-## Database Schema
-
-The following is the database schema for the project.
-
-```sql
--- WARNING: This schema is for context only and is not meant to be run.
--- Table order and constraints may not be valid for execution.
-
-CREATE TABLE public.leagues (
-  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  league_id text,
-  name character varying,
-  user_integration_id bigint,
-  season text,
-  total_rosters bigint,
-  status text,
-  user_id uuid DEFAULT auth.uid(),
-  CONSTRAINT leagues_pkey PRIMARY KEY (id),
-  CONSTRAINT leagues_user_integrations_id_fkey FOREIGN KEY (user_integration_id) REFERENCES public.user_integrations(id)
-);
-CREATE TABLE public.notes (
-  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  text text,
-  user_id uuid,
-  CONSTRAINT notes_pkey PRIMARY KEY (id)
-);
-CREATE TABLE public.user_integrations (
-  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  user_id uuid DEFAULT auth.uid(),
-  provider character varying,
-  provider_user_id text,
-  CONSTRAINT user_integrations_pkey PRIMARY KEY (id)
-);
-```
-
-## Development
-
-### `package-lock.json` Synchronization
-
-When making changes to dependencies in `package.json`, you must regenerate the `package-lock.json` file. This is crucial because our continuous integration (CI) pipeline uses the `npm ci` command, which requires `package.json` and `package-lock.json` to be perfectly in sync.
-
-If they are not in sync, the CI pipeline will fail with an error similar to this:
-`npm ERR! clean install a project with an out-of-sync lockfile`
-
-To prevent this, after any change in `package.json`, run the following command to update `package-lock.json`:
-
-```bash
-npm install
-```
-
-After running the command, be sure to commit the updated `package-lock.json` file along with your other changes. If you forget to do this, you will need to pull the latest changes, run `npm install`, and then push the updated `package-lock.json` file.
+CI installs from the lockfile. After **any** change to `package.json`,
+run `npm install` and commit the regenerated `package-lock.json` in the
+same commit — otherwise CI fails with
+`npm ERR! clean install a project with an out-of-sync lockfile`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,106 @@
+# Architecture
+
+High-level design of Roster Loom (a.k.a. fantasy-pulse).
+
+## Tech stack
+
+| Layer            | Choice                                                         |
+| ---------------- | -------------------------------------------------------------- |
+| Framework        | Next.js **15.3.6** (App Router, Turbopack dev)                 |
+| Language         | TypeScript 5                                                   |
+| Runtime          | Node **20.x** (`engines` + `.nvmrc`)                           |
+| UI               | React 18, Tailwind CSS 3, shadcn/Radix UI                      |
+| Auth + DB        | Supabase (Postgres + Auth, SSR via `@supabase/ssr`)            |
+| Unit tests       | Jest 29 + Testing Library (jsdom env)                          |
+| E2E tests        | Playwright 1.55 (CI-only; see [TESTING.md](TESTING.md))        |
+| Lint             | ESLint via `next lint` (`next/core-web-vitals`)                |
+| Hosting          | Firebase App Hosting (`apphosting.yaml`)                       |
+| Observability    | Vercel Speed Insights, `pino` logs, `performance-logger` utility |
+
+## Top-level layout
+
+```
+src/
+├── app/                # Next.js App Router
+│   ├── (dashboard)/    # Authenticated dashboard route group
+│   ├── api/            # Route handlers (OAuth callbacks, teams API)
+│   ├── integrations/   # One folder per provider (sleeper, yahoo, ottoneu)
+│   ├── login/  register/
+│   ├── actions.ts      # Cross-provider server actions (team building, scoring)
+│   ├── layout.tsx  page.tsx  loading.tsx
+│   └── globals.css
+├── components/         # App-specific + shadcn UI primitives (`components/ui`)
+├── hooks/              # React hooks (`use-mobile`, `use-toast`)
+├── lib/                # Shared types, sleeper helpers, env, fetch utilities
+├── utils/              # logger, performance-logger, supabase clients
+├── ai/                 # Generative AI helpers (currently `dev.ts`)
+└── middleware.ts       # Supabase session refresh middleware
+
+supabase/migrations/    # SQL migrations (source of truth for schema)
+e2e/                    # Playwright specs (do not run locally — see TESTING.md)
+```
+
+See [CODE_ORGANIZATION.md](CODE_ORGANIZATION.md) for module boundaries and conventions.
+
+## Data flow: live scoreboard
+
+```
+User → / (home)
+      → src/app/page.tsx (server component)
+        → src/app/actions.ts:buildAllTeams()
+          → for each user_integration:
+              → sleeper/actions.ts | yahoo/actions.ts | ottoneu/actions.ts
+                → external API (cached/throttled per provider)
+              → mapSleeperPlayer / Yahoo parser / Ottoneu scraper (JSDOM)
+            → merge into Team[] with cross-team Player share counts
+        → render PlayerCard grid with live scores + game progress
+```
+
+Every provider follows the same shape: an `actions.ts` (server), a `page.tsx`
+(integration management UI), a per-provider `README.md`, and an
+`*.example.json` snapshot for the most useful API response.
+
+## Provider integration pattern
+
+Each integration under `src/app/integrations/<provider>/`:
+
+- `actions.ts` — `'use server'` API calls + DB writes; export
+  `build<Provider>Teams` consumed by `src/app/actions.ts`
+- `actions.test.ts` — unit tests colocated next to implementation
+- `page.tsx` — UI for connecting and managing the integration
+- `README.md` — flow + payload shapes
+- `*.example.json` — captured API responses for reference and tests
+
+To add a new provider, follow [adding-integrations.md](adding-integrations.md).
+
+## Database
+
+Supabase Postgres. Schema is owned by SQL migrations in
+`supabase/migrations/` and reproduced for reference in
+[references/database-schema.md](references/database-schema.md).
+
+Core tables:
+
+- `user_integrations` — per-user provider connections (Sleeper ID, Yahoo
+  OAuth tokens, etc.)
+- `leagues` — league rows imported from each provider
+- `teams` — teams pulled from each league
+- `notes` — free-form user notes
+
+Server-side Supabase access goes through `src/utils/supabase/server.ts`;
+client-side through `src/utils/supabase/client.ts`. `middleware.ts`
+keeps sessions fresh on every request.
+
+## Performance discipline
+
+The home page assembles data from 1–3 external fantasy APIs on every
+load. Recent commits (see `git log`) have focused on:
+
+- `Promise.all` fan-out in `src/app/actions.ts`
+- Reusing Yahoo access tokens across a single request
+- Caching Sleeper player data (TTL in `actions.ts`)
+- `performance-logger.ts` wrapping every external call so we can spot
+  regressions in CI/observability
+
+When adding work to the home-page path, prefer batching and reuse over
+sequential awaits, and wrap external calls with `startTimer` / `logDuration`.

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -1,0 +1,98 @@
+# Code Organization
+
+Where things live and why. Pair this with [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## `src/app/` — Next.js App Router
+
+| Path                          | Purpose                                                |
+| ----------------------------- | ------------------------------------------------------ |
+| `page.tsx`                    | Public landing / home scoreboard                       |
+| `layout.tsx`                  | Root layout (fonts, providers, global chrome)          |
+| `loading.tsx`                 | Suspense fallback for `page.tsx`                       |
+| `globals.css`                 | Tailwind base layer + CSS variables                    |
+| `actions.ts`                  | Cross-provider server actions (team building, scoring) |
+| `actions.test.ts`             | Jest tests for `actions.ts`                            |
+| `(dashboard)/`                | Authenticated route group (matchup report, etc.)      |
+| `api/auth/<provider>/route.ts`| OAuth callbacks                                        |
+| `api/teams/`                  | Team-related route handlers                            |
+| `integrations/<provider>/`    | One folder per fantasy provider (see below)            |
+| `login/`, `register/`         | Auth pages                                             |
+
+## `src/app/integrations/<provider>/` — provider modules
+
+Every provider directory follows the **same five-file pattern**:
+
+```
+integrations/<provider>/
+├── actions.ts           # 'use server' API calls + DB writes
+├── actions.test.ts      # Jest tests, colocated
+├── page.tsx             # Connect / manage UI
+├── README.md            # Flow + payload shapes
+└── *.example.json       # Captured API response (when applicable)
+```
+
+Adding a new provider? Follow [adding-integrations.md](adding-integrations.md);
+it codifies this exact pattern.
+
+## `src/components/`
+
+- Top-level: app-specific components (`home-page.tsx`,
+  `player-card.tsx`, `app-navigation.tsx`, `matchup-priority-selector.tsx`)
+- `components/ui/`: shadcn/Radix primitives — treat as generated/library
+  code; only edit if you'd accept the change upstream.
+
+Component tests are colocated as `<name>.test.tsx` next to the implementation.
+
+## `src/lib/` — shared utilities
+
+- `types.ts`            shared TS types (Team, Player, SleeperLeague, etc.)
+- `sleeper.ts`          Sleeper-specific helpers reused across providers
+- `env.ts` + `env.test.ts`   env parsing/validation
+- `fetch-json.ts`       typed JSON fetch wrapper with retry semantics
+- `mock-data.ts`        fixtures for tests and dev
+- `utils.ts`            general helpers (`cn`, etc.)
+
+## `src/utils/`
+
+- `logger.ts`               pino-based structured logger
+- `performance-logger.ts`   `startTimer` / `logDuration` for external calls
+- `supabase/server.ts`      server-side Supabase client (App Router)
+- `supabase/client.ts`      browser Supabase client
+
+Anything that touches an external API should be timed with
+`performance-logger.ts` — this is the convention recent commits have been
+enforcing (see `git log --grep performance`).
+
+## `src/hooks/`
+
+Standard React hooks (`use-mobile`, `use-toast`). Hook tests colocated.
+
+## `src/ai/`
+
+Generative AI experiments. Currently just `dev.ts`. Not on the
+production code path.
+
+## `src/middleware.ts`
+
+Next.js middleware that refreshes Supabase sessions on every request.
+If you add new authenticated routes, ensure they are covered by the
+matcher.
+
+## `supabase/migrations/`
+
+Numbered SQL migrations are the **source of truth** for schema. Never
+edit a committed migration — add a new one. After changes, regenerate
+[references/database-schema.md](references/database-schema.md).
+
+## Module boundaries (rules)
+
+1. **Providers don't import providers.** `integrations/yahoo` must not
+   import from `integrations/sleeper`. Cross-provider orchestration
+   lives in `src/app/actions.ts`.
+2. **`'use server'` files don't get imported by client components**
+   except through Server Actions. Keep React Server Component code in
+   `page.tsx` / `layout.tsx`.
+3. **Supabase access is centralized** in `src/utils/supabase/`. Don't
+   `createClient(...)` ad-hoc elsewhere.
+4. **External calls go through `performance-logger`.** Wrap every fetch
+   with `startTimer` / `logDuration`.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,86 @@
+# Commands
+
+Every CLI command you need, grouped by domain. Package manager is **npm**.
+
+## Setup
+
+```bash
+nvm use                 # picks Node 20 from .nvmrc
+npm install             # install deps (also: regenerates package-lock.json)
+cp .env.example .env.local   # then fill in Supabase + Yahoo credentials
+```
+
+See [references/environment.md](references/environment.md) for what each
+env var does.
+
+## Dev server
+
+```bash
+npm run dev             # Next.js dev server with Turbopack on http://localhost:9002
+```
+
+Note: dev port is **9002**, not 3000. Playwright assumes this port.
+
+## Build / start (production)
+
+```bash
+npm run build           # next build
+npm start               # next start (after build)
+```
+
+## Tests
+
+```bash
+npm test                # Jest unit tests (jsdom)
+npm test -- path/to/file.test.ts   # single file
+npm test -- -t "name"   # by test name pattern
+```
+
+E2E tests exist but are **not run locally or by agents** — see
+[TESTING.md](TESTING.md) for why.
+
+## Lint + types
+
+```bash
+npm run lint            # next lint
+npm run typecheck       # tsc --noEmit
+```
+
+Run both before pushing. CI does not currently gate on them, but reviewers will.
+
+## Supabase
+
+The Supabase CLI is installed as a dev dependency.
+
+```bash
+npx supabase migration new <name>   # create a new SQL migration
+npx supabase db diff                # generate a migration from local changes
+npx supabase db push                # apply migrations to the linked project
+npx supabase gen types typescript --linked > src/lib/database.types.ts
+```
+
+After changing schema, regenerate the schema reference at
+[references/database-schema.md](references/database-schema.md).
+
+## Git + PRs
+
+```bash
+git checkout main && git pull origin main
+git checkout -b <type>/<short-description>
+# ... commit ...
+git push -u origin HEAD
+gh pr create --fill
+```
+
+See [GIT_WORKFLOW.md](GIT_WORKFLOW.md) for the full workflow.
+
+## Dependencies
+
+After **any** change to `package.json`:
+
+```bash
+npm install             # regenerates package-lock.json
+git add package.json package-lock.json
+```
+
+CI uses the lockfile; commits without an updated lockfile will fail to install.

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -1,0 +1,54 @@
+# Git Workflow
+
+## Branching
+
+- `main` is the only long-lived branch.
+- **Never commit directly to `main`.** Every change goes through a PR.
+- Always branch from an up-to-date `main`:
+
+  ```bash
+  git checkout main
+  git pull origin main
+  git checkout -b <type>/<short-description>
+  ```
+
+Branch name conventions (loose — match what shows up in `git log`):
+
+- `feat/...`  new user-visible feature
+- `fix/...`   bug fix
+- `chore/...` deps, tooling, refactors with no behavior change
+- `docs/...`  documentation only
+- `setup/...` repo infrastructure (e.g. `setup/harness-engineering`)
+
+## Commits
+
+- Imperative, sentence-case subject (`Add celebratory animation for refreshed scores`)
+- Recent history is the style guide — `git log --oneline -20` shows the
+  expected tone (often one-line summaries of the PR title).
+- Keep dependency bumps to their own commits/PRs (`chore: upgrade ...`).
+- After any `package.json` change, also stage the regenerated
+  `package-lock.json` in the same commit.
+
+## Pull requests
+
+GitHub repo: `alex-monroe/fantasy-pulse`. Open every PR with `gh`:
+
+```bash
+git push -u origin HEAD
+gh pr create --fill        # or --title / --body for custom text
+```
+
+Expectations:
+
+- PRs target `main`.
+- CI (Playwright) must be green before merge.
+- The PR description should explain the *why*; the diff already shows the *what*.
+- Bundle related changes — don't split refactors into 5 trivial PRs unless
+  there's a real reason.
+
+## What not to do
+
+- Don't force-push to `main` (it's the default and protected by convention).
+- Don't `git commit --no-verify` to skip hooks unless the user explicitly asks.
+- Don't run E2E tests locally to gate merging — rely on the CI report.
+- Don't amend a published commit; add a new commit instead.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,60 @@
+# Testing
+
+## Unit tests (Jest)
+
+- Runner: Jest 29 with `next/jest` config (`jest.config.js`)
+- Env: `jsdom` (so React component tests work out of the box)
+- Setup: `jest.setup.ts` (jest-dom matchers)
+- Pattern: tests are **colocated** next to the implementation as
+  `*.test.ts` / `*.test.tsx` (e.g. `src/app/actions.test.ts`,
+  `src/components/player-card.test.tsx`).
+- `e2e/` is excluded from Jest via `testPathIgnorePatterns`.
+
+Run:
+
+```bash
+npm test
+npm test -- src/app/actions.test.ts
+npm test -- -t "buildSleeperTeams"
+```
+
+When adding a new module under `src/app/integrations/<provider>/actions.ts`,
+add a sibling `actions.test.ts` — every existing provider follows this rule.
+
+## E2E tests (Playwright) — do not run locally
+
+E2E tests live under `e2e/` and are configured in `playwright.config.ts`
+(base URL `http://localhost:9002`, mocks injected via
+`e2e/mocks/external-apis.js`).
+
+**Agents must not run `npm run test:e2e`.** They are flaky, slow, and
+depend on a populated Supabase project. CI runs them on every push/PR
+via `.github/workflows/playwright.yml` and publishes a report to GitHub
+Pages; rely on that signal, not local runs.
+
+If you genuinely need to debug an E2E failure, do it in the CI report
+or hand it back to the human.
+
+## Test credentials
+
+For any login step in automated tests:
+
+- Email: `test@test.com`
+- Password: `test`
+
+## Lint and types
+
+`npm run lint` and `npm run typecheck` are not formal "tests" but are
+the next-fastest correctness signal. Run both before requesting review.
+
+## CI
+
+`.github/workflows/playwright.yml`:
+
+- triggers: push and PR to `main`
+- runs `npx playwright test` with real Supabase secrets
+- uploads the HTML report to GitHub Pages and comments the URL on the PR
+- the job fails if any Playwright test fails
+
+There is no separate unit-test job today. If you want one, add it as a
+standalone PR rather than bundling it with feature work.

--- a/docs/references/database-schema.md
+++ b/docs/references/database-schema.md
@@ -1,0 +1,51 @@
+# Database Schema (reference)
+
+> Source of truth is `supabase/migrations/`. This file is a snapshot for
+> agent context. **Do not execute this SQL** — table order and constraints
+> may not be valid for direct execution.
+
+Regenerate after schema changes (see [../COMMANDS.md](../COMMANDS.md) for
+the `supabase` CLI invocations).
+
+```sql
+CREATE TABLE public.leagues (
+  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  league_id text,
+  name character varying,
+  user_integration_id bigint,
+  season text,
+  total_rosters bigint,
+  status text,
+  user_id uuid DEFAULT auth.uid(),
+  CONSTRAINT leagues_pkey PRIMARY KEY (id),
+  CONSTRAINT leagues_user_integrations_id_fkey
+    FOREIGN KEY (user_integration_id)
+    REFERENCES public.user_integrations(id)
+);
+
+CREATE TABLE public.notes (
+  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  text text,
+  user_id uuid,
+  CONSTRAINT notes_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE public.user_integrations (
+  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  user_id uuid DEFAULT auth.uid(),
+  provider character varying,
+  provider_user_id text,
+  CONSTRAINT user_integrations_pkey PRIMARY KEY (id)
+);
+```
+
+A `teams` table also exists (added by
+`supabase/migrations/20250907113000_add_teams_table.sql` and constrained
+by `20250907123500_add_unique_constraint_to_teams_team_key.sql`); refer
+to those migrations for the authoritative definition.
+
+OAuth token columns were added to `user_integrations` by
+`20250906220000_add_oauth_tokens_to_user_integrations.sql`.

--- a/docs/references/environment.md
+++ b/docs/references/environment.md
@@ -1,0 +1,35 @@
+# Environment Variables
+
+Copy `.env.example` to `.env.local` and fill in. The dev server,
+Playwright, and `setup.sh` all read from `.env.local`.
+
+## Supabase
+
+| Variable                         | Where used                              | Notes |
+| -------------------------------- | --------------------------------------- | ----- |
+| `NEXT_PUBLIC_SUPABASE_URL`       | Browser + server Supabase clients       | Public — fine to expose. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY`  | Browser + server Supabase clients       | Public — RLS-protected. |
+| `SUPABASE_SERVICE_ROLE_KEY`      | Server-only privileged operations       | **Never expose to the browser.** Bypasses RLS. |
+
+## Yahoo OAuth
+
+| Variable             | Purpose                                              |
+| -------------------- | ---------------------------------------------------- |
+| `YAHOO_CLIENT_ID`    | OAuth client ID from the Yahoo developer console     |
+| `YAHOO_CLIENT_SECRET`| OAuth client secret — server-only                    |
+| `YAHOO_REDIRECT_URI` | OAuth callback URL (must match Yahoo app settings)   |
+
+The redirect URI in local dev is typically
+`http://localhost:9002/api/auth/yahoo` (note the **9002** dev port).
+
+## CI
+
+The GitHub Actions Playwright workflow pulls the three Supabase values
+from repo secrets with matching names. Yahoo credentials are not
+required for CI today — Yahoo flows are mocked at
+`e2e/mocks/external-apis.js`.
+
+## Sleeper / Ottoneu
+
+Neither provider requires API credentials. Sleeper is username-based,
+Ottoneu data is scraped from public pages.

--- a/src/lib/doc-map.test.ts
+++ b/src/lib/doc-map.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Ensures every doc referenced from AGENTS.md or CLAUDE.md actually exists.
+ *
+ * The map rots silently otherwise — a renamed or deleted doc leaves a
+ * broken pointer that future agents will dutifully try to read. See
+ * docs/CODE_ORGANIZATION.md for the rules behind this test.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+const MAP_FILES = ['AGENTS.md', 'CLAUDE.md'];
+
+// Matches relative markdown links: [text](docs/foo.md) or [text](./foo.md).
+// Skips absolute URLs (http, https, mailto) and pure anchors (#section).
+const LINK_RE = /\[[^\]]+\]\((?!https?:|mailto:|#)([^)#?]+)(?:[?#][^)]*)?\)/g;
+
+function extractLocalLinks(markdown: string): string[] {
+  const links: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = LINK_RE.exec(markdown)) !== null) {
+    links.push(m[1]);
+  }
+  return links;
+}
+
+describe('documentation map', () => {
+  for (const mapFile of MAP_FILES) {
+    describe(mapFile, () => {
+      const absMap = resolve(REPO_ROOT, mapFile);
+      const exists = existsSync(absMap);
+
+      it('exists at the repo root', () => {
+        expect(exists).toBe(true);
+      });
+
+      if (!exists) return;
+
+      const contents = readFileSync(absMap, 'utf8');
+      const links = extractLocalLinks(contents);
+
+      it('references at least one doc', () => {
+        expect(links.length).toBeGreaterThan(0);
+      });
+
+      it.each(links.map((l) => [l]))(
+        'links to an existing file: %s',
+        (link) => {
+          const target = resolve(dirname(absMap), link);
+          expect({ link, exists: existsSync(target) }).toEqual({
+            link,
+            exists: true,
+          });
+        },
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Applies harness-engineering principles (per [OpenAI's writeup](https://openai.com/index/harness-engineering/)) so AI coding agents land productive faster on this repo. The core idea: `AGENTS.md` is a **map**, not an encyclopedia — small entry point that points at deeper sources of truth in `docs/`.

## What changed

- **`AGENTS.md`** rewritten as a universal map (under 150 lines). The embedded DB-schema dump that previously bloated it moves to `docs/references/database-schema.md`.
- **`CLAUDE.md`** (new) — Claude-Code-specific extensions: dev port 9002, `npm`-only, available skills, MCP servers, repo naming quirk (repo is `fantasy-pulse`, product is "Roster Loom").
- **`docs/`** filled out:
  - `ARCHITECTURE.md` — stack, layout, data flow, provider pattern
  - `COMMANDS.md` — every CLI command grouped by domain
  - `TESTING.md` — Jest setup, why E2E is off-limits, CI signals
  - `GIT_WORKFLOW.md` — branch and PR rules
  - `CODE_ORGANIZATION.md` — file locations and module boundaries
  - `references/database-schema.md` — schema snapshot (regen after migrations)
  - `references/environment.md` — env var reference
- **`CONTRIBUTING.md`** trimmed to a pointer; no longer duplicates `AGENTS.md` content.
- **`.claude/commands/`** starter skills: `run-tests`, `start-dev`, `create-pr`, `db-types`, `retro`.
- **`src/lib/doc-map.test.ts`** — Jest test that fails if any markdown link in `AGENTS.md` / `CLAUDE.md` points at a missing file. Map rot is now caught mechanically instead of discovered the hard way.
- **`.gitignore`** excludes `.claude/settings.local.json` and `.mcp.json` (user-local Claude config). Team-shared skills under `.claude/commands/` remain tracked.

## Principles applied

1. **Map, not encyclopedia** — AGENTS.md stays small; detail lives in `docs/`.
2. **Progressive disclosure** — agents start with the map and navigate to detail.
3. **Repository-local knowledge** — decisions encoded in the repo, not Slack.
4. **Mechanical enforcement** — `doc-map.test.ts` enforces what prose otherwise just hopes for.
5. **Commands early** — `COMMANDS.md` lists everything an agent needs to build, test, and run.

## Test plan

- [x] `npm test -- src/lib/doc-map.test.ts` — 22 assertions, all pass
- [x] `npm test` full suite — 90 passing (2 failures in `src/app/actions.test.ts` are pre-existing on `main`, unrelated)
- [x] `npm run typecheck` — new `doc-map.test.ts` types cleanly (existing errors in `mock-data.ts`, `types.ts`, `supabase/server.ts` predate this PR)
- [x] `npm run lint` — clean (one pre-existing warning unrelated to this PR)
- [ ] Playwright CI on this PR (will run automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)