### PR TITLE
Fix Yahoo actions tests and re-enable register e2e

### DIFF
--- a/e2e/register.spec.ts
+++ b/e2e/register.spec.ts
@@ -1,28 +1,32 @@
 import { test, expect } from 'playwright/test';
-import { createClient } from '@supabase/supabase-js';
 
-// TODO: re-enable after fixing flake on OttoneuDB-backed CI.
-test.skip('user can register', async ({ page }) => {
+test('user can register', async ({ page }) => {
   const email = `user${Date.now()}@example.com`;
   const password = 'test1234';
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+  // Intercept Supabase signUp so the test doesn't depend on project-level
+  // email-domain validation (the shared OttoneuDB project rejects
+  // @example.com) or shared signup rate limits.
+  await page.route('**/auth/v1/signup*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: '00000000-0000-0000-0000-000000000001',
+          email,
+          aud: 'authenticated',
+          role: 'authenticated',
+        },
+        session: null,
+      }),
+    });
+  });
 
-  try {
-    await page.goto('/register');
-    await page.getByLabel('Email').fill(email);
-    await page.getByLabel('Password').fill(password);
-    await page.getByRole('button', { name: 'Create Account' }).click();
-    await expect(page).toHaveURL('/login');
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-  } finally {
-    const { data: { users } } = await supabase.auth.admin.listUsers();
-    const user = users.find(u => u.email === email);
-    if (user) {
-        await supabase.auth.admin.deleteUser(user.id);
-    }
-  }
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Create Account' }).click();
+  await expect(page).toHaveURL('/login');
+  await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
 });

--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -423,7 +423,7 @@ describe('actions', () => {
       );
       expect(getYahooPlayerScores).toHaveBeenCalledWith(
         'int-2',
-        'user-team-key',
+        'yahoo-team-1',
         'token',
         1
       );
@@ -474,7 +474,16 @@ describe('actions', () => {
 
       expect(result).toEqual([]);
       expect(getYahooRoster).toHaveBeenCalledTimes(2);
-      expect(getYahooPlayerScores).not.toHaveBeenCalled();
+      // User player scores are prefetched alongside matchups (PR #177), so
+      // the call has already fired by the time we discover the roster error.
+      // We never request opponent scores, so only the prefetch should show up.
+      expect(getYahooPlayerScores).toHaveBeenCalledTimes(1);
+      expect(getYahooPlayerScores).toHaveBeenCalledWith(
+        'int-2',
+        'yahoo-team-1',
+        'token',
+        1
+      );
     });
 
     it('logs and continues when player score fetch rejects', async () => {


### PR DESCRIPTION
## Summary

- **Unit tests:** Fix the two failing `buildYahooTeams` assertions in `src/app/actions.test.ts`. PR #177 added a prefetch of user player scores using `team.team_key` (from `getYahooUserTeams`) before matchups are fetched, but the tests still asserted the post-matchups `userTeam.team_key` and that no score fetch had happened on a roster error. The asserts now match the prefetch behavior.
- **Register e2e:** Re-enable `e2e/register.spec.ts`. The CI failure on the OttoneuDB migration PR showed `Email address "userN@example.com" is invalid` on the page — the new shared Supabase project rejects `@example.com`, which the retired project allowed. Rather than relying on project-level email-domain rules, intercept `/auth/v1/signup` via `page.route()` and return a shaped-correct success response. The test still drives the real register page; only the auth backend is mocked.

## Test plan

- [x] `npm test` — 92 passing
- [ ] CI playwright run — verify `e2e/register.spec.ts` passes (and the other 3 e2e specs still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)