### PR TITLE
refactor: prefix app tables with fp_ on shared OttoneuDB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,13 @@ docs/
 - **Update the docs map** when you add/rename files referenced from
   `AGENTS.md` or `CLAUDE.md`. The Jest test in `src/lib/doc-map.test.ts`
   will fail otherwise.
+- **Shared Supabase project (OttoneuDB).** This project is shared with
+  another repo. Every table owned by **this** repo is prefixed `fp_`
+  (for fantasy-pulse): `fp_user_integrations`, `fp_leagues`, `fp_teams`,
+  `fp_notes` (plus the standard `auth.*` / `storage.*` schemas managed
+  by Supabase). Any non-`fp_` public table you see via the `supabase`
+  MCP tools belongs to the sibling repo — **do not** drop, alter,
+  rename, or suggest "cleaning up" those tables, and do not assume
+  their presence indicates a bug here. When adding new tables in this
+  repo, give them an `fp_` prefix. If a schema change here would
+  affect a non-`fp_` table, stop and ask.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,13 +79,14 @@ Supabase Postgres. Schema is owned by SQL migrations in
 `supabase/migrations/` and reproduced for reference in
 [references/database-schema.md](references/database-schema.md).
 
-Core tables:
+Core tables (all prefixed `fp_` to distinguish them from the sibling
+repo's tables on the shared OttoneuDB project):
 
-- `user_integrations` — per-user provider connections (Sleeper ID, Yahoo
-  OAuth tokens, etc.)
-- `leagues` — league rows imported from each provider
-- `teams` — teams pulled from each league
-- `notes` — free-form user notes
+- `fp_user_integrations` — per-user provider connections (Sleeper ID,
+  Yahoo OAuth tokens, etc.)
+- `fp_leagues` — league rows imported from each provider
+- `fp_teams` — teams pulled from each league
+- `fp_notes` — free-form user notes
 
 Server-side Supabase access goes through `src/utils/supabase/server.ts`;
 client-side through `src/utils/supabase/client.ts`. `middleware.ts`

--- a/docs/references/database-schema.md
+++ b/docs/references/database-schema.md
@@ -7,8 +7,13 @@
 Regenerate after schema changes (see [../COMMANDS.md](../COMMANDS.md) for
 the `supabase` CLI invocations).
 
+All Roster Loom tables carry an `fp_` prefix to distinguish them from
+the sibling repo's tables on the shared OttoneuDB Supabase project.
+Historical migrations created the tables under their unprefixed names;
+`20260518120000_rename_app_tables_with_fp_prefix.sql` renamed them.
+
 ```sql
-CREATE TABLE public.leagues (
+CREATE TABLE public.fp_leagues (
   id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   league_id text,
@@ -21,10 +26,10 @@ CREATE TABLE public.leagues (
   CONSTRAINT leagues_pkey PRIMARY KEY (id),
   CONSTRAINT leagues_user_integrations_id_fkey
     FOREIGN KEY (user_integration_id)
-    REFERENCES public.user_integrations(id)
+    REFERENCES public.fp_user_integrations(id)
 );
 
-CREATE TABLE public.notes (
+CREATE TABLE public.fp_notes (
   id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   text text,
@@ -32,7 +37,7 @@ CREATE TABLE public.notes (
   CONSTRAINT notes_pkey PRIMARY KEY (id)
 );
 
-CREATE TABLE public.user_integrations (
+CREATE TABLE public.fp_user_integrations (
   id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   user_id uuid DEFAULT auth.uid(),
@@ -42,10 +47,17 @@ CREATE TABLE public.user_integrations (
 );
 ```
 
-A `teams` table also exists (added by
+A `fp_teams` table also exists (originally created as `teams` by
 `supabase/migrations/20250907113000_add_teams_table.sql` and constrained
 by `20250907123500_add_unique_constraint_to_teams_team_key.sql`); refer
 to those migrations for the authoritative definition.
 
-OAuth token columns were added to `user_integrations` by
+OAuth token columns were added to `fp_user_integrations` (then named
+`user_integrations`) by
 `20250906220000_add_oauth_tokens_to_user_integrations.sql`.
+
+Note: constraint and index names (e.g. `leagues_pkey`,
+`leagues_user_integrations_id_fkey`) kept their original unprefixed
+names — `ALTER TABLE ... RENAME TO` does not rename embedded
+constraints, and the names are stable identifiers Postgres uses
+internally. Future constraints should use the `fp_` prefix.

--- a/docs/references/environment.md
+++ b/docs/references/environment.md
@@ -8,9 +8,10 @@ Playwright, and `setup.sh` all read from `.env.local`.
 Roster Loom shares the **`OttoneuDB`** Supabase project (ref
 `rbinbcwinchphipvcfqk`). It was migrated from a standalone
 `fantasy-pulse` project in May 2026 to consolidate fantasy-football
-infrastructure under one project; the four app tables (`notes`,
-`user_integrations`, `leagues`, `teams`) coexist with OttoneuDB's
-unrelated tables in the `public` schema.
+infrastructure under one project; Roster Loom's tables all carry an
+`fp_` prefix (`fp_user_integrations`, `fp_leagues`, `fp_teams`,
+`fp_notes`) so they're visually distinct from OttoneuDB's unrelated
+tables in the `public` schema.
 
 Pull project credentials from the
 [OttoneuDB API settings](https://supabase.com/dashboard/project/rbinbcwinchphipvcfqk/settings/api-keys).

--- a/e2e/main-page.spec.ts
+++ b/e2e/main-page.spec.ts
@@ -27,14 +27,14 @@ test.describe('Main Page', () => {
 
     // Insert mock integrations and leagues
     const { data: sleeper, error: sleeperError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({ user_id: user.id, provider: 'sleeper', provider_user_id: 'sleeperUser' })
       .select()
       .single();
     if (sleeperError) throw sleeperError;
     sleeperIntegration = sleeper;
 
-    await supabase.from('leagues').insert({
+    await supabase.from('fp_leagues').insert({
       league_id: 'league1',
       name: 'Mock Sleeper League',
       user_integration_id: sleeper.id,
@@ -45,7 +45,7 @@ test.describe('Main Page', () => {
     });
 
     const { data: yahoo, error: yahooError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'yahoo',
@@ -60,7 +60,7 @@ test.describe('Main Page', () => {
     yahooIntegration = yahoo;
 
     const { data: ottoneu, error: ottoneuError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'ottoneu',
@@ -71,7 +71,7 @@ test.describe('Main Page', () => {
     if (ottoneuError) throw ottoneuError;
     ottoneuIntegration = ottoneu;
 
-    await supabase.from('leagues').insert({
+    await supabase.from('fp_leagues').insert({
       league_id: '309',
       name: 'The SOFA',
       user_integration_id: ottoneu.id,
@@ -85,15 +85,15 @@ test.describe('Main Page', () => {
   test.afterAll(async () => {
     if (user) {
       await supabase
-        .from('teams')
+        .from('fp_teams')
         .delete()
         .eq('user_integration_id', yahooIntegration.id);
       await supabase
-        .from('teams')
+        .from('fp_teams')
         .delete()
         .eq('user_integration_id', ottoneuIntegration.id);
-      await supabase.from('leagues').delete().eq('user_id', user.id);
-      await supabase.from('user_integrations').delete().eq('user_id', user.id);
+      await supabase.from('fp_leagues').delete().eq('user_id', user.id);
+      await supabase.from('fp_user_integrations').delete().eq('user_id', user.id);
       await supabase.auth.admin.deleteUser(user.id);
     }
   });

--- a/e2e/matchup-report.spec.ts
+++ b/e2e/matchup-report.spec.ts
@@ -34,7 +34,7 @@ test.describe('Matchup Report Page', () => {
         status: string;
       }
     ) => {
-      const { error: leagueError } = await supabase.from('leagues').insert({
+      const { error: leagueError } = await supabase.from('fp_leagues').insert({
         ...league,
         user_integration_id: userIntegrationId,
         user_id: user.id,
@@ -43,7 +43,7 @@ test.describe('Matchup Report Page', () => {
     };
 
     const { data: sleeperUser, error: sleeperUserError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'sleeper',
@@ -62,7 +62,7 @@ test.describe('Matchup Report Page', () => {
     });
 
     const { data: sleeperOpponent, error: sleeperOpponentError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'sleeper',
@@ -83,7 +83,7 @@ test.describe('Matchup Report Page', () => {
     const expiresAt = new Date(Date.now() + 3600 * 1000).toISOString();
 
     const { data: yahooOne, error: yahooOneError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'yahoo',
@@ -98,7 +98,7 @@ test.describe('Matchup Report Page', () => {
     yahooIntegrations.push(yahooOne);
 
     const { data: yahooTwo, error: yahooTwoError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'yahoo',
@@ -113,7 +113,7 @@ test.describe('Matchup Report Page', () => {
     yahooIntegrations.push(yahooTwo);
 
     const { data: ottoneuOne, error: ottoneuOneError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'ottoneu',
@@ -132,7 +132,7 @@ test.describe('Matchup Report Page', () => {
     });
 
     const { data: ottoneuTwo, error: ottoneuTwoError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'ottoneu',
@@ -159,10 +159,10 @@ test.describe('Matchup Report Page', () => {
         ...ottoneuIntegrations,
       ];
       for (const integration of allIntegrations) {
-        await supabase.from('teams').delete().eq('user_integration_id', integration.id);
-        await supabase.from('leagues').delete().eq('user_integration_id', integration.id);
+        await supabase.from('fp_teams').delete().eq('user_integration_id', integration.id);
+        await supabase.from('fp_leagues').delete().eq('user_integration_id', integration.id);
       }
-      await supabase.from('user_integrations').delete().eq('user_id', user.id);
+      await supabase.from('fp_user_integrations').delete().eq('user_id', user.id);
       await supabase.auth.admin.deleteUser(user.id);
     }
   });

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1068,7 +1068,7 @@ export async function getTeams() {
 
   const integrationsStart = startTimer();
   const { data: integrations, error: integrationsError } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .select('*')
     .eq('user_id', user.id);
   logDuration('getTeams: load integrations', integrationsStart, {

--- a/src/app/api/auth/yahoo/route.ts
+++ b/src/app/api/auth/yahoo/route.ts
@@ -66,7 +66,7 @@ export async function GET(request: Request) {
     const expires_at = new Date(Date.now() + expires_in * 1000).toISOString();
 
     const { error: insertError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'yahoo',

--- a/src/app/integrations/ottoneu/actions.test.ts
+++ b/src/app/integrations/ottoneu/actions.test.ts
@@ -196,10 +196,10 @@ describe('ottoneu actions', () => {
             .mockResolvedValue({ data: { user: { id: 'user-1' } } }),
         },
         from: jest.fn((table: string) => {
-          if (table === 'user_integrations') {
+          if (table === 'fp_user_integrations') {
             return { insert: insertMock } as any;
           }
-          if (table === 'leagues') {
+          if (table === 'fp_leagues') {
             return { upsert: upsertMock } as any;
           }
           return {} as any;

--- a/src/app/integrations/ottoneu/actions.ts
+++ b/src/app/integrations/ottoneu/actions.ts
@@ -303,7 +303,7 @@ export async function connectOttoneu(
   const { teamName, leagueName, leagueId, teamId, matchup } = info;
 
   const { data: integration, error: insertError } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .insert({
       user_id: user.id,
       provider: 'ottoneu',
@@ -316,7 +316,7 @@ export async function connectOttoneu(
     return { error: insertError.message };
   }
 
-  const { error: leagueError } = await supabase.from('leagues').upsert({
+  const { error: leagueError } = await supabase.from('fp_leagues').upsert({
     league_id: leagueId,
     name: leagueName,
     user_integration_id: integration.id,
@@ -337,7 +337,7 @@ export async function removeOttoneuIntegration(integrationId: number) {
   const supabase = createClient();
 
   const { error: deleteLeaguesError } = await supabase
-    .from('leagues')
+    .from('fp_leagues')
     .delete()
     .eq('user_integration_id', integrationId);
 
@@ -346,7 +346,7 @@ export async function removeOttoneuIntegration(integrationId: number) {
   }
 
   const { error: deleteIntegrationError } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .delete()
     .eq('id', integrationId);
 
@@ -368,7 +368,7 @@ export async function getOttoneuIntegration() {
   }
 
   const { data, error } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .select('*')
     .eq('user_id', user.id)
     .eq('provider', 'ottoneu')
@@ -388,7 +388,7 @@ export async function getOttoneuIntegration() {
 export async function getLeagues(integrationId: number) {
   const supabase = createClient();
   const { data, error } = await supabase
-    .from('leagues')
+    .from('fp_leagues')
     .select('*')
     .eq('user_integration_id', integrationId);
 

--- a/src/app/integrations/sleeper/README.md
+++ b/src/app/integrations/sleeper/README.md
@@ -8,14 +8,14 @@ The Sleeper integration allows users to connect their Sleeper account to the app
 
 The integration flow is as follows:
 
-1.  **Authentication**: The user provides their Sleeper username. The application uses this to fetch the user's account information from the Sleeper API. The user's Sleeper ID is then securely stored in the `user_integrations` table in the database.
+1.  **Authentication**: The user provides their Sleeper username. The application uses this to fetch the user's account information from the Sleeper API. The user's Sleeper ID is then securely stored in the `fp_user_integrations` table in the database.
 
 2.  **Data Fetching**: With the user's Sleeper ID, the application can make requests to the Sleeper API to fetch data. The following functions in `src/app/integrations/sleeper/actions.ts` are responsible for fetching data:
     *   `getSleeperLeagues`: Fetches the user's leagues for the current season.
     *   `getRosters`: Fetches the rosters for a specific league.
     *   `getNflPlayers`: Fetches all NFL players from the Sleeper API.
 
-3.  **Data Storage**: The data fetched from the Sleeper API is then parsed and stored in the application's database. For example, league data is stored in the `leagues` table. This allows the application to use the data without having to repeatedly call the Sleeper API.
+3.  **Data Storage**: The data fetched from the Sleeper API is then parsed and stored in the application's database. For example, league data is stored in the `fp_leagues` table. This allows the application to use the data without having to repeatedly call the Sleeper API.
 
 ## Data Formats
 

--- a/src/app/integrations/sleeper/actions.ts
+++ b/src/app/integrations/sleeper/actions.ts
@@ -37,7 +37,7 @@ export async function connectSleeper(username: string) {
     }
 
     const { error: insertError } = await supabase
-      .from('user_integrations')
+      .from('fp_user_integrations')
       .insert({
         user_id: user.id,
         provider: 'sleeper',
@@ -64,7 +64,7 @@ export async function removeSleeperIntegration(integrationId: number) {
 
   // First, delete all leagues associated with the integration
   const { error: deleteLeaguesError } = await supabase
-    .from('leagues')
+    .from('fp_leagues')
     .delete()
     .eq('user_integration_id', integrationId);
 
@@ -74,7 +74,7 @@ export async function removeSleeperIntegration(integrationId: number) {
 
   // Then, delete the integration itself
   const { error: deleteIntegrationError } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .delete()
     .eq('id', integrationId);
 
@@ -93,7 +93,7 @@ export async function removeSleeperIntegration(integrationId: number) {
 export async function getLeagues(integrationId: number) {
   const supabase = createClient();
   const { data, error } = await supabase
-    .from('leagues')
+    .from('fp_leagues')
     .select('*')
     .eq('user_integration_id', integrationId);
 
@@ -117,7 +117,7 @@ export async function getSleeperIntegration() {
   }
 
   const { data, error } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .select('*')
     .eq('user_id', user.id)
     .eq('provider', 'sleeper')
@@ -157,7 +157,7 @@ export async function getSleeperLeagues(userId: string, integrationId: number) {
         status: league.status,
       }));
 
-      const { error: insertError } = await supabase.from('leagues').upsert(leaguesToInsert);
+      const { error: insertError } = await supabase.from('fp_leagues').upsert(leaguesToInsert);
       if (insertError) {
         return { error: insertError.message };
       }

--- a/src/app/integrations/yahoo/actions.ts
+++ b/src/app/integrations/yahoo/actions.ts
@@ -51,7 +51,7 @@ export async function getYahooAccessToken(integrationId: number): Promise<{ acce
   }
 
   const { data: integration, error: integrationError } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .select('access_token, refresh_token, expires_at')
     .eq('id', integrationId)
     .eq('user_id', user.id)
@@ -103,7 +103,7 @@ export async function getYahooAccessToken(integrationId: number): Promise<{ acce
       const newExpiresAt = new Date(Date.now() + data.expires_in * 1000).toISOString();
 
       const { error: updateError } = await supabase
-        .from('user_integrations')
+        .from('fp_user_integrations')
         .update({
           access_token: data.access_token,
           refresh_token: data.refresh_token || integration.refresh_token, // Yahoo may issue a new refresh token
@@ -150,7 +150,7 @@ export async function removeYahooIntegration(integrationId: number) {
 
   // First, delete all teams associated with the integration
   const { error: deleteTeamsError } = await supabase
-    .from('teams')
+    .from('fp_teams')
     .delete()
     .eq('user_integration_id', integrationId);
 
@@ -160,7 +160,7 @@ export async function removeYahooIntegration(integrationId: number) {
 
   // Then, delete all leagues associated with the integration
   const { error: deleteLeaguesError } = await supabase
-    .from('leagues')
+    .from('fp_leagues')
     .delete()
     .eq('user_integration_id', integrationId);
 
@@ -170,7 +170,7 @@ export async function removeYahooIntegration(integrationId: number) {
 
   // Then, delete the integration itself
   const { error: deleteIntegrationError } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .delete()
     .eq('id', integrationId);
 
@@ -189,7 +189,7 @@ export async function removeYahooIntegration(integrationId: number) {
 export async function getLeagues(integrationId: number) {
   const supabase = createClient();
   const { data, error } = await supabase
-    .from('leagues')
+    .from('fp_leagues')
     .select('*')
     .eq('user_integration_id', integrationId);
 
@@ -208,7 +208,7 @@ export async function getLeagues(integrationId: number) {
 export async function getTeams(integrationId: number) {
   const supabase = createClient();
   const { data, error } = await supabase
-    .from('teams')
+    .from('fp_teams')
     .select('*')
     .eq('user_integration_id', integrationId);
 
@@ -305,7 +305,7 @@ export async function getYahooUserTeams(integrationId: number) {
     if (teamsToInsert.length > 0) {
       const supabase = createClient();
       const { data: upsertedTeams, error: upsertError } = await supabase
-        .from('teams')
+        .from('fp_teams')
         .upsert(teamsToInsert, { onConflict: 'team_key,user_integration_id' })
         .select();
 
@@ -341,7 +341,7 @@ export async function getYahooIntegration() {
   }
 
   const { data, error } = await supabase
-    .from('user_integrations')
+    .from('fp_user_integrations')
     .select('*')
     .eq('user_id', user.id)
     .eq('provider', 'yahoo')
@@ -433,7 +433,7 @@ export async function getYahooLeagues(integrationId: number) {
     if (leaguesToInsert.length > 0) {
       const supabase = createClient();
       const { data: upsertedLeagues, error: upsertError } = await supabase
-        .from('leagues')
+        .from('fp_leagues')
         .upsert(leaguesToInsert, { onConflict: 'league_id' })
         .select();
 

--- a/supabase/migrations/20260518120000_rename_app_tables_with_fp_prefix.sql
+++ b/supabase/migrations/20260518120000_rename_app_tables_with_fp_prefix.sql
@@ -1,0 +1,9 @@
+-- Rename Roster Loom's tables with an fp_ prefix so the boundary
+-- with the sibling repo sharing the OttoneuDB Supabase project is
+-- explicit. Foreign keys auto-update to the new table identities;
+-- existing constraint/index names (e.g. leagues_pkey) keep their
+-- original names and remain valid.
+ALTER TABLE public.user_integrations RENAME TO fp_user_integrations;
+ALTER TABLE public.leagues RENAME TO fp_leagues;
+ALTER TABLE public.teams RENAME TO fp_teams;
+ALTER TABLE public.notes RENAME TO fp_notes;


### PR DESCRIPTION
## Summary

- Rename Roster Loom's four tables on the shared OttoneuDB Supabase project so the boundary with the sibling repo is visible at a glance: `leagues → fp_leagues`, `notes → fp_notes`, `teams → fp_teams`, `user_integrations → fp_user_integrations`.
- Updates every `.from('…')` call site in app code, the two e2e specs, and the ottoneu actions test mock; refreshes docs (`CLAUDE.md`, `ARCHITECTURE.md`, `docs/references/database-schema.md`, `docs/references/environment.md`, the Sleeper integration README).
- The CLAUDE.md "Shared Supabase project" rule now reads as "anything without an `fp_` prefix belongs to the sibling repo — do not touch."

## Migration

`supabase/migrations/20260518120000_rename_app_tables_with_fp_prefix.sql` is just four `ALTER TABLE … RENAME TO …` statements. Postgres auto-updates the foreign key targeting `user_integrations(id)`; constraint/index names (e.g. `leagues_pkey`) keep their unprefixed names — that's cosmetic and stable.

## ⚠️ Deploy coordination

The migration **must run on OttoneuDB at the same time as this code lands** — once the rename is applied, the deployed app will 404 on Supabase queries until the new build ships, and vice versa. Recommended order:

1. Merge this PR (do not deploy yet).
2. `npx supabase db push` (or apply via dashboard) to run the rename on the OttoneuDB project.
3. Deploy the new build immediately after.

If you want a zero-downtime path, that's a different shape (create `fp_*` views over the old tables, deploy code, then drop the old names) — happy to do that instead if needed.

## Test plan

- [x] `npm test` — 92/92 jest tests pass locally
- [ ] CI Playwright run on this PR (the e2e specs were updated; they hit Supabase directly)
- [ ] After migration + deploy: smoke-test that integrations page lists leagues and the home scoreboard renders teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)