### PR TITLE
chore: gitignore supabase/.temp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ playwright-report/
 .claude/settings.local.json
 # mcp (contains secrets)
 .mcp.json
+
+# Supabase CLI local cache (project ref, service versions, etc.)
+supabase/.temp/


### PR DESCRIPTION
## Summary

- The Supabase CLI writes local cache files (project ref, gotrue/postgres versions, pooler URL) into `supabase/.temp/` whenever you run `npx supabase status` or similar. None of them belong in source control.

## Test plan

- [x] After applying the ignore, `git status` no longer surfaces the six `supabase/.temp/*` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)