### PR TITLE
feat(mobile): scoreboard screen powered by /api/teams/refresh

### DIFF
--- a/.github/workflows/mobile-preview.yml
+++ b/.github/workflows/mobile-preview.yml
@@ -49,6 +49,10 @@ jobs:
           # builds don't show the red-screen error overlay).
           EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          # Web base URL the mobile app calls for /api/teams/refresh.
+          # PR-preview mobile bundles always hit production web — they
+          # don't try to pair with a sibling web PR preview.
+          EXPO_PUBLIC_API_URL: https://www.rosterloom.com
         with:
           working-directory: apps/mobile
           # NB: avoid `#` in the message string — YAML treats ` # ` (space-hash)

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,2 +1,6 @@
 EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# Base URL of the Roster Loom web app; mobile calls /api/teams/refresh against this.
+# Use https://www.rosterloom.com for production; for local web dev,
+# use http://<your-LAN-IP>:9002 (mobile devices can't reach localhost).
+EXPO_PUBLIC_API_URL=https://www.rosterloom.com

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,69 +1,82 @@
-import { useEffect, useState } from 'react';
-import { ActivityIndicator, Button, FlatList, StyleSheet, View } from 'react-native';
+import type { Player, Team } from '@roster-loom/core';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Button,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  View,
+} from 'react-native';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
+import { fetchTeams } from '@/lib/api';
 import { useSession } from '@/lib/session';
 import { supabase } from '@/lib/supabase';
 
-type League = {
-  id: number;
-  name: string | null;
-  season: string | null;
-  status: string | null;
-  total_rosters: number | null;
-};
-
-export default function LeaguesScreen() {
+export default function ScoreboardScreen() {
   const { session } = useSession();
-  const [leagues, setLeagues] = useState<League[] | null>(null);
+  const [teams, setTeams] = useState<Team[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  const load = useCallback(async () => {
+    setError(null);
+    const result = await fetchTeams();
+    if ('error' in result) setError(result.error);
+    else setTeams(result.teams);
+  }, []);
 
   useEffect(() => {
-    supabase
-      .from('fp_leagues')
-      .select('id, name, season, status, total_rosters')
-      .order('created_at', { ascending: false })
-      .then(({ data, error: err }) => {
-        if (err) setError(err.message);
-        else setLeagues(data ?? []);
-      });
-  }, []);
+    void load();
+  }, [load]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  }, [load]);
+
+  const toggle = (teamId: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(teamId) ? next.delete(teamId) : next.add(teamId);
+      return next;
+    });
+  };
 
   return (
     <ThemedView style={styles.container}>
-      <ThemedText type="title" style={styles.heading}>
-        Your leagues
-      </ThemedText>
-      <ThemedText style={styles.subtle}>Signed in as {session?.user.email}</ThemedText>
+      <View style={styles.header}>
+        <ThemedText type="title">Matchups</ThemedText>
+        <ThemedText style={styles.subtle}>{session?.user.email}</ThemedText>
+      </View>
 
       {error && (
-        <ThemedText style={styles.error} testID="leagues-error">
+        <ThemedText style={styles.error} testID="scoreboard-error">
           {error}
         </ThemedText>
       )}
 
-      {!error && leagues === null && <ActivityIndicator style={styles.loading} />}
+      {!error && teams === null && <ActivityIndicator style={styles.loading} />}
 
-      {leagues?.length === 0 && (
+      {teams && teams.length === 0 && (
         <ThemedText style={styles.empty}>
-          No leagues yet — connect a provider from the web app.
+          No teams yet. Connect Sleeper, Yahoo, or Ottoneu from the web app.
         </ThemedText>
       )}
 
-      {leagues && leagues.length > 0 && (
+      {teams && teams.length > 0 && (
         <FlatList
-          data={leagues}
-          keyExtractor={(item) => String(item.id)}
+          data={teams}
+          keyExtractor={(t) => String(t.id)}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+          contentContainerStyle={styles.list}
           renderItem={({ item }) => (
-            <View style={styles.row}>
-              <ThemedText type="defaultSemiBold">{item.name ?? 'Untitled league'}</ThemedText>
-              <ThemedText style={styles.subtle}>
-                {[item.season, item.status, item.total_rosters && `${item.total_rosters} teams`]
-                  .filter(Boolean)
-                  .join(' · ')}
-              </ThemedText>
-            </View>
+            <TeamRow team={item} expanded={expanded.has(item.id)} onToggle={() => toggle(item.id)} />
           )}
         />
       )}
@@ -75,13 +88,121 @@ export default function LeaguesScreen() {
   );
 }
 
+function TeamRow({
+  team,
+  expanded,
+  onToggle,
+}: {
+  team: Team;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const winning = team.totalScore >= team.opponent.totalScore;
+  return (
+    <View style={styles.card}>
+      <Pressable onPress={onToggle} style={styles.cardHeader} accessibilityRole="button">
+        <View style={styles.teamLine}>
+          <ThemedText
+            type="defaultSemiBold"
+            style={[styles.teamName, winning && styles.winning]}
+            numberOfLines={1}>
+            {team.name}
+          </ThemedText>
+          <ThemedText
+            type="defaultSemiBold"
+            style={[styles.score, winning && styles.winning]}>
+            {team.totalScore.toFixed(1)}
+          </ThemedText>
+        </View>
+        <View style={styles.teamLine}>
+          <ThemedText style={[styles.teamName, styles.opponent]} numberOfLines={1}>
+            {team.opponent.name}
+          </ThemedText>
+          <ThemedText style={[styles.score, styles.opponent]}>
+            {team.opponent.totalScore.toFixed(1)}
+          </ThemedText>
+        </View>
+        <ThemedText style={styles.expandHint}>
+          {expanded ? 'Tap to collapse' : 'Tap for players'}
+        </ThemedText>
+      </Pressable>
+
+      {expanded && (
+        <View style={styles.players}>
+          {team.players.length === 0 ? (
+            <ThemedText style={styles.subtle}>No players.</ThemedText>
+          ) : (
+            team.players.map((p) => <PlayerRow key={p.id} player={p} />)
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function PlayerRow({ player }: { player: Player }) {
+  return (
+    <View style={styles.playerRow}>
+      <View style={styles.playerLeft}>
+        <ThemedText style={styles.position}>{player.position || '—'}</ThemedText>
+        <View style={styles.playerNameWrap}>
+          <ThemedText numberOfLines={1}>{player.name}</ThemedText>
+          <ThemedText style={styles.realTeam} numberOfLines={1}>
+            {[player.realTeam, player.gameStatus].filter(Boolean).join(' · ')}
+          </ThemedText>
+        </View>
+      </View>
+      <ThemedText type="defaultSemiBold">{player.score.toFixed(1)}</ThemedText>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16, gap: 8 },
-  heading: { marginTop: 8 },
-  subtle: { opacity: 0.7 },
-  error: { color: '#c0392b', marginTop: 12 },
+  container: { flex: 1, paddingTop: 8 },
+  header: { paddingHorizontal: 16, paddingVertical: 8 },
+  subtle: { opacity: 0.6, fontSize: 13 },
+  error: { color: '#c0392b', paddingHorizontal: 16, marginTop: 12 },
   loading: { marginTop: 24 },
-  empty: { marginTop: 24, opacity: 0.7 },
-  row: { paddingVertical: 12, borderBottomWidth: StyleSheet.hairlineWidth, borderColor: '#888' },
-  signOut: { marginTop: 24 },
+  empty: { marginTop: 24, marginHorizontal: 16, opacity: 0.7 },
+  list: { paddingHorizontal: 12, paddingBottom: 12 },
+  card: {
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#888',
+    marginVertical: 6,
+    overflow: 'hidden',
+  },
+  cardHeader: { padding: 12 },
+  teamLine: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 2,
+  },
+  teamName: { flex: 1 },
+  opponent: { opacity: 0.7 },
+  winning: { color: '#0a7d2f' },
+  score: { minWidth: 56, textAlign: 'right' },
+  expandHint: { marginTop: 6, fontSize: 11, opacity: 0.5 },
+  players: { borderTopWidth: StyleSheet.hairlineWidth, borderColor: '#888' },
+  playerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ccc',
+  },
+  playerLeft: { flexDirection: 'row', flex: 1, alignItems: 'center', gap: 10 },
+  position: {
+    minWidth: 36,
+    fontVariant: ['tabular-nums'],
+    fontSize: 12,
+    opacity: 0.7,
+  },
+  playerNameWrap: { flex: 1 },
+  realTeam: { fontSize: 11, opacity: 0.6 },
+  signOut: { paddingHorizontal: 16, paddingBottom: 16, marginTop: 8 },
 });

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -1,0 +1,51 @@
+import type { Team } from '@roster-loom/core';
+
+import { supabase } from '@/lib/supabase';
+
+const rawBase = process.env.EXPO_PUBLIC_API_URL;
+if (!rawBase) {
+  throw new Error(
+    'Missing EXPO_PUBLIC_API_URL. Copy apps/mobile/.env.example to .env.local and fill it in.',
+  );
+}
+const API_BASE = rawBase.replace(/\/+$/, '');
+
+export type TeamsResponse = { teams: Team[] } | { error: string };
+
+/**
+ * Fetches the user's teams + scores from the web app's /api/teams/refresh
+ * endpoint. Authenticates with the current Supabase session JWT.
+ *
+ * Returns `{ teams }` on success, `{ error }` on auth/server failure.
+ */
+export async function fetchTeams(): Promise<TeamsResponse> {
+  const { data, error: sessionError } = await supabase.auth.getSession();
+  if (sessionError) return { error: sessionError.message };
+  const token = data.session?.access_token;
+  if (!token) return { error: 'Not signed in.' };
+
+  const response = await fetch(`${API_BASE}/api/teams/refresh`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  let body: unknown = null;
+  try {
+    body = await response.json();
+  } catch {
+    return { error: `HTTP ${response.status}: response was not JSON` };
+  }
+
+  if (!response.ok || (body && typeof body === 'object' && 'error' in body)) {
+    const message =
+      body && typeof body === 'object' && 'error' in body && typeof body.error === 'string'
+        ? body.error
+        : `HTTP ${response.status}`;
+    return { error: message };
+  }
+
+  return body as TeamsResponse;
+}

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { cookies } from 'next/headers';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabase/server';
 import { logDuration, startTimer } from '@/utils/performance-logger';
 import { getLeagues as getSleeperLeagues } from '@/app/integrations/sleeper/actions';
@@ -1052,11 +1053,11 @@ export async function getTeamBuilders() {
  * Gets the user's teams from all integrated platforms.
  * @returns A list of teams.
  */
-export async function getTeams() {
+export async function getTeams(client?: SupabaseClient) {
   const overallStart = startTimer();
   console.log('[performance] getTeams invoked');
 
-  const supabase = createClient();
+  const supabase = client ?? createClient();
 
   const userStart = startTimer();
   const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -1053,25 +1053,29 @@ export async function getTeamBuilders() {
  * Gets the user's teams from all integrated platforms.
  * @returns A list of teams.
  */
-export async function getTeams(client?: SupabaseClient) {
+export async function getTeams(client?: SupabaseClient, userId?: string) {
   const overallStart = startTimer();
   console.log('[performance] getTeams invoked');
 
   const supabase = client ?? createClient();
 
-  const userStart = startTimer();
-  const { data: { user } } = await supabase.auth.getUser();
-  logDuration('getTeams: fetch user', userStart, { hasUser: Boolean(user) });
-  if (!user) {
-    logDuration('getTeams total', overallStart, { result: 'no-user' });
-    return { error: 'You must be logged in.' };
+  let resolvedUserId = userId;
+  if (!resolvedUserId) {
+    const userStart = startTimer();
+    const { data: { user } } = await supabase.auth.getUser();
+    logDuration('getTeams: fetch user', userStart, { hasUser: Boolean(user) });
+    if (!user) {
+      logDuration('getTeams total', overallStart, { result: 'no-user' });
+      return { error: 'You must be logged in.' };
+    }
+    resolvedUserId = user.id;
   }
 
   const integrationsStart = startTimer();
   const { data: integrations, error: integrationsError } = await supabase
     .from('fp_user_integrations')
     .select('*')
-    .eq('user_id', user.id);
+    .eq('user_id', resolvedUserId);
   logDuration('getTeams: load integrations', integrationsStart, {
     integrationCount: integrations?.length ?? 0,
   });

--- a/apps/web/src/app/api/teams/refresh/route.ts
+++ b/apps/web/src/app/api/teams/refresh/route.ts
@@ -17,12 +17,25 @@ export async function POST(request: Request) {
   console.log('[performance] refresh teams endpoint invoked');
 
   const authHeader = request.headers.get('authorization');
-  const bearerClient = authHeader?.toLowerCase().startsWith('bearer ')
-    ? createApiClient(authHeader)
-    : undefined;
+  const isBearer = authHeader?.toLowerCase().startsWith('bearer ') ?? false;
+  let bearerClient: ReturnType<typeof createApiClient> | undefined;
+  let bearerUserId: string | undefined;
+
+  if (isBearer && authHeader) {
+    bearerClient = createApiClient(authHeader);
+    // supabase.auth.getUser() with no arg reads from an in-memory session
+    // (we don't have one server-side); the JWT overload sends the token
+    // straight to /auth/v1/user and returns the verified user.
+    const token = authHeader.replace(/^bearer\s+/i, '').trim();
+    const { data, error: authError } = await bearerClient.auth.getUser(token);
+    if (authError || !data.user) {
+      return NextResponse.json({ error: 'Invalid or expired token.' }, { status: 401 });
+    }
+    bearerUserId = data.user.id;
+  }
 
   try {
-    const result = await getTeams(bearerClient);
+    const result = await getTeams(bearerClient, bearerUserId);
 
     if ('error' in result) {
       const status = result.error === 'You must be logged in.' ? 401 : 500;

--- a/apps/web/src/app/api/teams/refresh/route.ts
+++ b/apps/web/src/app/api/teams/refresh/route.ts
@@ -1,18 +1,28 @@
 import { NextResponse } from 'next/server';
 import { getTeams } from '@/app/actions';
+import { createApiClient } from '@/utils/supabase/api';
 import { logDuration, startTimer } from '@/utils/performance-logger';
 
 export const dynamic = 'force-dynamic';
 
 /**
  * Fetches the latest teams and scores from all configured providers.
+ *
+ * Auth: cookie-based for browser callers (Next.js RSC / fetch from the
+ * web app); `Authorization: Bearer <jwt>` for non-browser callers like
+ * the mobile app.
  */
-export async function POST() {
+export async function POST(request: Request) {
   const overallStart = startTimer();
   console.log('[performance] refresh teams endpoint invoked');
 
+  const authHeader = request.headers.get('authorization');
+  const bearerClient = authHeader?.toLowerCase().startsWith('bearer ')
+    ? createApiClient(authHeader)
+    : undefined;
+
   try {
-    const result = await getTeams();
+    const result = await getTeams(bearerClient);
 
     if ('error' in result) {
       const status = result.error === 'You must be logged in.' ? 401 : 500;

--- a/apps/web/src/utils/supabase/api.ts
+++ b/apps/web/src/utils/supabase/api.ts
@@ -1,0 +1,31 @@
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Bearer-token Supabase client for API routes called from non-browser
+ * clients (mobile, scripts) that authenticate via the standard
+ * `Authorization: Bearer <jwt>` header instead of cookies.
+ *
+ * The JWT is forwarded on every PostgREST request so RLS policies see
+ * `auth.uid()` set to the user. Sessions are not persisted on the
+ * server — each request authenticates independently.
+ */
+export function createApiClient(authHeader: string | null | undefined) {
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice('Bearer '.length).trim()
+    : null;
+
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      global: {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      },
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder leagues tab with a real scoreboard. Mobile becomes a thin display layer over the web app's `/api/teams/refresh` endpoint; the existing 1277-line cross-provider orchestration in `apps/web/src/app/actions.ts` (Sleeper + Yahoo OAuth refresh + Ottoneu scrape) runs server-side, unchanged, and isn't duplicated on mobile.

## How auth works

Mobile sends its Supabase session JWT as `Authorization: Bearer <token>`. Web detects the header and constructs a per-request Supabase client that forwards the JWT on every PostgREST call — RLS still enforces `auth.uid() = user_id`. If no Bearer header is present, the route falls back to its existing cookie-based behavior, so the web app's own usage is unchanged.

## Setup step (one-time, after pulling)

```bash
# Add the new env var to your local mobile .env file
echo "EXPO_PUBLIC_API_URL=https://www.rosterloom.com" >> apps/mobile/.env.local
```

The CI workflow already passes this for preview builds.

## UX

- FlatList of teams, each rendered as a card with **your score · opponent score** (winning side green)
- Tap a card to expand → player list with position, name, real-team, game status, fantasy points
- Pull-to-refresh
- Empty state for users with no integrations connected
- Sign-out button below the list

## Files

- `apps/web/src/utils/supabase/api.ts` — new `createApiClient(authHeader)` builds a JWT-forwarding Supabase client. Sessions not persisted on the server.
- `apps/web/src/app/actions.ts` — `getTeams()` now accepts an optional `SupabaseClient` (defaults to cookie client; web RSC call site unchanged).
- `apps/web/src/app/api/teams/refresh/route.ts` — picks Bearer auth when present.
- `apps/mobile/lib/api.ts` — typed `fetchTeams()` returning `{ teams }` or `{ error }`.
- `apps/mobile/app/(tabs)/index.tsx` — scoreboard UI.
- `apps/mobile/.env.example` — adds `EXPO_PUBLIC_API_URL`.
- `.github/workflows/mobile-preview.yml` — forwards `EXPO_PUBLIC_API_URL=https://www.rosterloom.com` into the build.

## Verification

- `npm test` — web 96/96, mobile 1/1
- `npx expo export --platform ios` — 4.11 MB Hermes bundle, clean
- Mobile preview workflow will run on this PR; scan the QR to test end-to-end against prod data

## Test plan

- [ ] Mobile preview workflow runs and posts QR comment
- [ ] Scan QR in Expo Go, sign in with `test@test.com` / `testtest`, see teams + opponent scores
- [ ] Tap a team card, confirm player list shows positions / names / scores
- [ ] Pull down to refresh; data updates
- [ ] Web app still renders the home scoreboard normally (no regression to cookie auth path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)