### PR TITLE
fix(web): Bearer-auth API route was running PostgREST as anon

### DIFF
--- a/apps/web/src/utils/supabase/api.ts
+++ b/apps/web/src/utils/supabase/api.ts
@@ -5,9 +5,12 @@ import { createClient as createSupabaseClient } from '@supabase/supabase-js';
  * clients (mobile, scripts) that authenticate via the standard
  * `Authorization: Bearer <jwt>` header instead of cookies.
  *
- * The JWT is forwarded on every PostgREST request so RLS policies see
- * `auth.uid()` set to the user. Sessions are not persisted on the
- * server — each request authenticates independently.
+ * Uses the `accessToken` option (v2.45+) so supabase-js forwards the
+ * provided JWT on every PostgREST and Realtime request. An earlier
+ * implementation set the token in `global.headers.Authorization`,
+ * which PostgREST silently overrode with the (empty) session token —
+ * queries ran as the anon role, RLS denied everything, and the route
+ * returned empty arrays with no visible error.
  */
 export function createApiClient(authHeader: string | null | undefined) {
   const token = authHeader?.startsWith('Bearer ')
@@ -18,9 +21,7 @@ export function createApiClient(authHeader: string | null | undefined) {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      global: {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      },
+      accessToken: token ? async () => token : undefined,
       auth: {
         persistSession: false,
         autoRefreshToken: false,


### PR DESCRIPTION
## Summary

Bug introduced in #204: \`createApiClient\` set the user JWT in \`global.headers.Authorization\`, but supabase-js's PostgREST module overrides Authorization per-request from the in-memory session — which is empty server-side. PostgREST received only the anon apikey, queries ran as the anon role, RLS denied (\`auth.uid() = user_id\` is never true when \`auth.uid()\` is null), and \`/api/teams/refresh\` returned \`{ teams: [] }\` with no error to surface.

Symptom: TestFlight build signed in fine, but the scoreboard always showed the "No teams yet — connect Sleeper, Yahoo, or Ottoneu" empty state, even for users with all three providers connected.

## Fix

One-line: switch from \`global.headers.Authorization\` to the \`accessToken\` option (supabase-js v2.45+), which is the designed pattern for "always use this token, ignore session state." It applies to both PostgREST and Realtime clients.

## Mobile rebuild required?

**No.** Mobile already calls \`https://www.rosterloom.com/api/teams/refresh\` correctly — the bug was entirely server-side. Once Vercel redeploys main after merge, the existing TestFlight build will start receiving the user's teams.

## Verification

- Web 96/96 tests pass
- Pre-existing typecheck warnings unchanged

## Test plan

- [ ] Merge + wait for Vercel to deploy main
- [ ] Open TestFlight build (no rebuild needed), sign in with alexrmonroe@gmail.com, verify all 3 integrations' teams appear on the scoreboard
- [ ] Also verify web rosterloom.com home still renders correctly (cookie-auth path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)