### PR TITLE
Refactor Sleeper league fetching to resolve live each season

### DIFF
--- a/apps/web/e2e/mocks/external-apis.js
+++ b/apps/web/e2e/mocks/external-apis.js
@@ -36,6 +36,21 @@ global.fetch = async (input, init) => {
     });
   }
 
+  // The scoreboard resolves a user's leagues live each season (Sleeper mints a
+  // new league_id every year), so mock the current-season leagues endpoint for
+  // any Sleeper user id. Both the user and their opponent map to league1.
+  if (/^https:\/\/api\.sleeper\.app\/v1\/user\/[^/]+\/leagues\/nfl\/\d+$/.test(url)) {
+    return jsonResponse([
+      {
+        league_id: 'league1',
+        name: 'Mock Sleeper League',
+        season: '2024',
+        total_rosters: 2,
+        status: 'in_season',
+      },
+    ]);
+  }
+
   if (url === 'https://api.sleeper.app/v1/league/league1/rosters') {
     return jsonResponse([
       { roster_id: 1, owner_id: 'sleeperUser', players: ['p1'], starters: ['p1'] },

--- a/apps/web/src/app/actions.test.ts
+++ b/apps/web/src/app/actions.test.ts
@@ -3,7 +3,7 @@ const { getTeams, buildSleeperTeams, buildYahooTeams, invalidateSleeperPlayersCa
 import { mapSleeperPlayer } from '@roster-loom/core';
 import { SleeperRoster, SleeperMatchup, SleeperUser, SleeperPlayer } from '@roster-loom/core';
 import { createClient } from '@/utils/supabase/server';
-import { getLeagues } from '@/app/integrations/sleeper/actions';
+import { getCurrentSleeperLeagues } from '@/app/integrations/sleeper/actions';
 import {
   getYahooUserTeams,
   getYahooRoster,
@@ -21,7 +21,7 @@ jest.mock('@/utils/supabase/server', () => ({
 }));
 
 jest.mock('@/app/integrations/sleeper/actions', () => ({
-  getLeagues: jest.fn(),
+  getCurrentSleeperLeagues: jest.fn(),
 }));
 
 jest.mock('@/app/integrations/yahoo/actions', () => ({
@@ -106,7 +106,7 @@ describe('actions', () => {
     (fetch as jest.Mock).mockReset();
 
     (createClient as jest.Mock).mockReturnValue(mockSupabase);
-    (getLeagues as jest.Mock).mockClear();
+    (getCurrentSleeperLeagues as jest.Mock).mockClear();
     (getYahooUserTeams as jest.Mock).mockClear();
     (getYahooRoster as jest.Mock).mockClear();
     (getYahooMatchups as jest.Mock).mockClear();
@@ -217,7 +217,7 @@ describe('actions', () => {
     ];
 
     it('returns empty array when getLeagues fails', async () => {
-      (getLeagues as jest.Mock).mockResolvedValue({ leagues: null, error: 'err' });
+      (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({ leagues: null, error: 'err' });
       const result = await buildSleeperTeams(
         { id: 1, provider_user_id: 'sleeper-user-1' },
         1,
@@ -227,7 +227,7 @@ describe('actions', () => {
     });
 
     it('builds sleeper teams correctly', async () => {
-      (getLeagues as jest.Mock).mockResolvedValue({
+      (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({
         leagues: [{ id: 1, league_id: 'sleeper-league-1' }],
         error: null,
       });
@@ -245,10 +245,13 @@ describe('actions', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Team A');
+      // Leagues must be resolved live by Sleeper user id so a new season's
+      // league_id is picked up, not read from the stale connect-time copy.
+      expect(getCurrentSleeperLeagues).toHaveBeenCalledWith('sleeper-user-1');
     });
 
     it('skips leagues when sleeper data is incomplete', async () => {
-      (getLeagues as jest.Mock).mockResolvedValue({
+      (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({
         leagues: [{ id: 1, league_id: 'sleeper-league-1' }],
         error: null,
       });
@@ -268,7 +271,7 @@ describe('actions', () => {
     });
 
     it('omits players without Sleeper player data', async () => {
-      (getLeagues as jest.Mock).mockResolvedValue({
+      (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({
         leagues: [{ id: 1, league_id: 'sleeper-league-1' }],
         error: null,
       });
@@ -618,7 +621,7 @@ describe('actions', () => {
         .mockResolvedValueOnce({ json: () => Promise.resolve(mockMatchups) }) // matchupsResponse
         .mockResolvedValueOnce({ json: () => Promise.resolve(mockLeagueUsers) }); // leagueUsersResponse
 
-      (getLeagues as jest.Mock).mockResolvedValue({
+      (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({
         leagues: [{ id: 'league-1', league_id: 'sleeper-league-1' }],
         error: null,
       });
@@ -694,7 +697,7 @@ describe('actions', () => {
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockScoreboard) })
         .mockResolvedValueOnce({ json: () => Promise.resolve(mockPlayersData) });
 
-      (getLeagues as jest.Mock).mockResolvedValue({
+      (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({
         leagues: null,
         error: 'Failed to fetch leagues',
       });

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabase/server';
 import { logDuration, startTimer } from '@/utils/performance-logger';
-import { getLeagues as getSleeperLeagues } from '@/app/integrations/sleeper/actions';
+import { getCurrentSleeperLeagues } from '@/app/integrations/sleeper/actions';
 import {
   getYahooUserTeams,
   getYahooRoster,
@@ -465,7 +465,12 @@ export async function buildSleeperTeams(
   const { playersData } =
     playerResources ?? (await getSleeperPlayersResources());
 
-  const { leagues, error: leaguesError } = await getSleeperLeagues(integration.id);
+  // Resolve leagues live from Sleeper each build: Sleeper issues a new
+  // league_id every season, so the copy saved to fp_leagues at connect time
+  // goes stale after a season rollover and would surface last year's rosters.
+  const { leagues, error: leaguesError } = await getCurrentSleeperLeagues(
+    integration.provider_user_id
+  );
   if (leaguesError || !leagues) {
     return [];
   }

--- a/apps/web/src/app/integrations/sleeper/actions.test.ts
+++ b/apps/web/src/app/integrations/sleeper/actions.test.ts
@@ -1,4 +1,4 @@
-import { getMatchups } from './actions';
+import { getMatchups, getCurrentSleeperLeagues } from './actions';
 import { fetchJson } from '@roster-loom/core';
 
 jest.mock('@roster-loom/core', () => ({ fetchJson: jest.fn() }));
@@ -6,6 +6,32 @@ jest.mock('@roster-loom/core', () => ({ fetchJson: jest.fn() }));
 describe('sleeper actions', () => {
   beforeEach(() => {
     (fetchJson as jest.Mock).mockReset();
+  });
+
+  describe('getCurrentSleeperLeagues', () => {
+    it('fetches leagues for the current NFL season', async () => {
+      (fetchJson as jest.Mock).mockResolvedValue({
+        data: [{ league_id: 'new-season-league' }],
+      });
+      const year = new Date().getFullYear();
+      const result = await getCurrentSleeperLeagues('sleeper-user-1');
+      expect(fetchJson).toHaveBeenCalledWith(
+        `https://api.sleeper.app/v1/user/sleeper-user-1/leagues/nfl/${year}`
+      );
+      expect(result).toEqual({ leagues: [{ league_id: 'new-season-league' }] });
+    });
+
+    it('returns an empty list when the user has no leagues yet', async () => {
+      (fetchJson as jest.Mock).mockResolvedValue({ data: null });
+      const result = await getCurrentSleeperLeagues('sleeper-user-1');
+      expect(result).toEqual({ leagues: [] });
+    });
+
+    it('returns error on failure', async () => {
+      (fetchJson as jest.Mock).mockResolvedValue({ error: 'fail' });
+      const result = await getCurrentSleeperLeagues('sleeper-user-1');
+      expect(result).toEqual({ error: 'fail' });
+    });
   });
 
   it('returns matchups on success', async () => {

--- a/apps/web/src/app/integrations/sleeper/actions.ts
+++ b/apps/web/src/app/integrations/sleeper/actions.ts
@@ -131,6 +131,33 @@ export async function getSleeperIntegration() {
 }
 
 /**
+ * Fetches a user's Sleeper leagues for the current NFL season directly from
+ * the Sleeper API, without touching the database.
+ *
+ * Sleeper mints a brand-new `league_id` for every season (the prior season's
+ * league lives on as `previous_league_id`), so the scoreboard must resolve
+ * leagues live each season rather than trusting the copy saved at connect
+ * time. See {@link getSleeperLeagues} for the connect-time persist path.
+ * @param userId - The Sleeper user ID.
+ * @returns The current season's leagues or an error.
+ */
+export async function getCurrentSleeperLeagues(userId: string) {
+  try {
+    const year = new Date().getFullYear();
+    const { data: leagues, error } = await fetchJson<SleeperLeague[]>(
+      `https://api.sleeper.app/v1/user/${userId}/leagues/nfl/${year}`
+    );
+    if (error) {
+      return { error };
+    }
+
+    return { leagues: leagues ?? [] };
+  } catch (error) {
+    return { error: 'An unexpected error occurred' };
+  }
+}
+
+/**
  * Gets the Sleeper leagues for a user and inserts them into the database.
  * @param userId - The Sleeper user ID.
  * @param integrationId - The ID of the integration.
@@ -139,10 +166,7 @@ export async function getSleeperIntegration() {
 export async function getSleeperLeagues(userId: string, integrationId: number) {
   const supabase = createClient();
   try {
-    const year = new Date().getFullYear();
-    const { data: leagues, error } = await fetchJson<SleeperLeague[]>(
-      `https://api.sleeper.app/v1/user/${userId}/leagues/nfl/${year}`
-    );
+    const { leagues, error } = await getCurrentSleeperLeagues(userId);
     if (error) {
       return { error };
     }


### PR DESCRIPTION
## Summary

Extracts the Sleeper API call for fetching current season leagues into a new `getCurrentSleeperLeagues()` function and updates `buildSleeperTeams()` to call it directly with the user ID instead of relying on the stale database copy. This ensures the scoreboard picks up new `league_id` values that Sleeper mints each season, rather than surfacing last year's rosters after a season rollover.

## Key Changes

- **New function `getCurrentSleeperLeagues(userId)`** in `apps/web/src/app/integrations/sleeper/actions.ts`
  - Fetches leagues directly from Sleeper API for the current NFL season
  - Returns leagues or error; handles null data gracefully (returns empty array)
  - Includes comprehensive JSDoc explaining why live resolution is necessary

- **Refactored `getSleeperLeagues()`** to use the new function
  - Eliminates duplicate API call logic
  - Maintains database persistence behavior for connect-time storage

- **Updated `buildSleeperTeams()`** in `apps/web/src/app/actions.ts`
  - Now calls `getCurrentSleeperLeagues(provider_user_id)` instead of `getSleeperLeagues(integration.id)`
  - Added comment explaining the seasonal league ID rotation requirement

- **Test coverage**
  - Added three test cases for `getCurrentSleeperLeagues()` covering success, null data, and error paths
  - Updated all mock references in `apps/web/src/app/actions.test.ts` to use the new function name
  - Added assertion verifying the function is called with the correct user ID

## Implementation Details

Sleeper issues a new `league_id` for every season; the prior season's league becomes `previous_league_id`. The database copy saved at connect time goes stale after season rollover. By resolving leagues live on each build, the scoreboard will automatically surface the current season's rosters without requiring users to reconnect their integration.

https://claude.ai/code/session_01JMaTUr5VY1ioAneVhD7mUS