### PR TITLE
ci(mobile): run PR preview bundles in demo mode

### DIFF
--- a/.github/workflows/mobile-preview.yml
+++ b/.github/workflows/mobile-preview.yml
@@ -53,6 +53,12 @@ jobs:
           # PR-preview mobile bundles always hit production web — they
           # don't try to pair with a sibling web PR preview.
           EXPO_PUBLIC_API_URL: https://www.rosterloom.com
+          # PR-preview bundles run in demo mode: the app sends an
+          # x-demo-mode header (honored by production /api/teams/refresh)
+          # and polls every 30s, so reviewers can exercise the live
+          # scoreboard with deterministic fake data regardless of season
+          # or connected leagues. See docs/DEMO_MODE.md.
+          EXPO_PUBLIC_DEMO_MODE: '1'
         with:
           working-directory: apps/mobile
           # NB: avoid `#` in the message string — YAML treats ` # ` (space-hash)

--- a/docs/DEMO_MODE.md
+++ b/docs/DEMO_MODE.md
@@ -57,6 +57,16 @@ DEMO_MODE=1 npm run dev            # then open http://localhost:9002
 EXPO_PUBLIC_DEMO_MODE=1 npm run mobile
 ```
 
+## PR preview builds
+
+The `mobile-preview.yml` workflow publishes an `eas update` bundle for
+every PR that touches `apps/mobile/**` or `packages/core/**` and posts a
+QR code to the PR. Those bundles are built with `EXPO_PUBLIC_DEMO_MODE=1`
+and point at production web, so **every mobile PR preview runs in demo
+mode** — reviewers can scan the QR and see a live-looking scoreboard
+without an in-season Sunday or connected leagues. Production App Store /
+TestFlight builds are unaffected (they don't set the flag).
+
 ## Real headshots
 
 Demo players use reliable initials-avatar placeholders. To show real


### PR DESCRIPTION
## What & why

Follow-up to #210 (demo mode). Enables demo mode for the mobile **PR preview bundles** so reviewers can exercise the live scoreboard from a PR — no in-season Sunday and no connected leagues required.

## How it works

`mobile-preview.yml` publishes an `eas update` bundle for every PR touching `apps/mobile/**` or `packages/core/**` and posts a QR code. `EXPO_PUBLIC_*` vars are inlined into the JS bundle by Metro at export time. This PR adds:

```yaml
EXPO_PUBLIC_DEMO_MODE: '1'
```

to that step's `env` block. At runtime `apps/mobile/lib/api.ts` reads the flag, sends an `x-demo-mode: 1` header on `/api/teams/refresh`, and polls every 30s. The preview bundle already targets production web (`EXPO_PUBLIC_API_URL=https://www.rosterloom.com`), whose `/api/teams/refresh` route (merged in #210) honors that header — so **no server change is needed**.

## Scope / safety

- Affects **only** the PR-preview `eas update` bundles. Production App Store / TestFlight builds don't set the flag and are unaffected.
- One CI env var + a `docs/DEMO_MODE.md` note documenting the behavior. No app or server code changes.

## Testing

CI-only change; validated the workflow YAML parses and `EXPO_PUBLIC_DEMO_MODE` resolves to the string `'1'` (matched by the `api.ts` flag check). End-to-end verification happens when this workflow runs on a mobile-touching PR and the QR bundle shows the demo scoreboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzBgKp1YagA7hmDrSovMPb)_