### PR TITLE
Add Model Context Protocol (MCP) server for AI assistant integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ matchup data with cross-team player-share indicators.
 - **Git workflow:** [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) — branch + PR rules
 - **Add a provider:** [docs/adding-integrations.md](docs/adding-integrations.md)
 - **Mobile app:** [docs/MOBILE.md](docs/MOBILE.md)
+- **MCP server:** [docs/MCP.md](docs/MCP.md) — hosted AI-assistant access
 - **DB schema:** [docs/references/database-schema.md](docs/references/database-schema.md)
 - **Env vars:** [docs/references/environment.md](docs/references/environment.md)
 
@@ -44,6 +45,7 @@ docs/
 ├── TESTING.md                     # Jest setup, E2E policy, CI signals
 ├── GIT_WORKFLOW.md                # Branch + PR rules
 ├── MOBILE.md                      # Mobile app quickstart (Expo Go, env, layout)
+├── MCP.md                         # Hosted MCP server: tools, tokens, transport
 ├── adding-integrations.md         # How to add a new fantasy provider
 ├── blueprint.md                   # Original product brief (style + features)
 └── references/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ token reuse, caching) matters more than feature volume.
 - **Add a provider:** [docs/adding-integrations.md](docs/adding-integrations.md)
 - **Demo mode:** [docs/DEMO_MODE.md](docs/DEMO_MODE.md)
 - **Mobile app:** [docs/MOBILE.md](docs/MOBILE.md)
+- **MCP server:** [docs/MCP.md](docs/MCP.md)
 - **DB schema:** [docs/references/database-schema.md](docs/references/database-schema.md)
 - **Env vars:** [docs/references/environment.md](docs/references/environment.md)
 
@@ -62,6 +63,7 @@ docs/
 ├── TESTING.md                     # Jest setup, E2E policy, CI signals
 ├── GIT_WORKFLOW.md                # Branch + PR rules
 ├── DEMO_MODE.md                   # Fake-data mode for out-of-season testing
+├── MCP.md                         # Hosted MCP server: tools, tokens, transport
 ├── adding-integrations.md         # How to add a new fantasy provider
 ├── blueprint.md                   # Original product brief
 └── references/

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,10 +6,14 @@ export default defineConfig({
   testDir: './e2e',
   reporter: 'html',
   outputDir: 'test-results/',
+  // The suite drives a live Supabase project, so a single slow render can
+  // time out a spec that is otherwise fine. Retry in CI so one flake does
+  // not fail the whole job; keep local runs at zero so flakes stay visible.
+  retries: process.env.CI ? 2 : 0,
   use: {
     baseURL: 'http://localhost:9002',
     video: 'on',
-    trace: 'on-fail',
+    trace: 'retain-on-failure',
   },
   webServer: {
     command: 'npm run dev',

--- a/apps/web/src/app/(dashboard)/mcp/actions.ts
+++ b/apps/web/src/app/(dashboard)/mcp/actions.ts
@@ -1,0 +1,119 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { createClient } from '@/utils/supabase/server';
+import { mintMcpToken } from '@/lib/mcp/tokens';
+
+/** A stored token as shown in the management UI. Never includes the secret. */
+export type McpTokenRecord = {
+  id: number;
+  name: string;
+  token_prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+};
+
+/**
+ * Lists the current user's MCP tokens, newest first.
+ *
+ * @returns The tokens, or an error message.
+ */
+export async function listMcpTokens(): Promise<
+  { tokens: McpTokenRecord[] } | { error: string }
+> {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in.' };
+  }
+
+  const { data, error } = await supabase
+    .from('fp_mcp_tokens')
+    .select('id, name, token_prefix, created_at, last_used_at')
+    .eq('user_id', user.id)
+    .is('revoked_at', null)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { tokens: (data ?? []) as McpTokenRecord[] };
+}
+
+/**
+ * Mints a new MCP access token for the current user.
+ *
+ * The plaintext token is returned once here and never stored, so the
+ * caller must surface it immediately.
+ *
+ * @param name - A label to identify the token later.
+ * @returns The plaintext token, or an error message.
+ */
+export async function createMcpToken(
+  name: string,
+): Promise<{ token: string } | { error: string }> {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in.' };
+  }
+
+  const trimmedName = name.trim().slice(0, 80) || 'MCP token';
+  const { token, tokenHash, tokenPrefix } = mintMcpToken();
+
+  const { error } = await supabase.from('fp_mcp_tokens').insert({
+    user_id: user.id,
+    name: trimmedName,
+    token_hash: tokenHash,
+    token_prefix: tokenPrefix,
+  });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  revalidatePath('/mcp');
+
+  return { token };
+}
+
+/**
+ * Revokes a token, immediately invalidating it for MCP requests.
+ *
+ * @param id - The token's id.
+ * @returns Success, or an error message.
+ */
+export async function revokeMcpToken(
+  id: number,
+): Promise<{ success: true } | { error: string }> {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'You must be logged in.' };
+  }
+
+  const { error } = await supabase
+    .from('fp_mcp_tokens')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('user_id', user.id);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  revalidatePath('/mcp');
+
+  return { success: true };
+}

--- a/apps/web/src/app/(dashboard)/mcp/components.tsx
+++ b/apps/web/src/app/(dashboard)/mcp/components.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Copy, KeyRound, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+
+import { createMcpToken, revokeMcpToken, type McpTokenRecord } from './actions';
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return 'never';
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'unknown' : date.toLocaleString();
+}
+
+/**
+ * Token creation form plus the list of active tokens.
+ *
+ * @param tokens - The user's existing tokens.
+ * @param serverUrl - Absolute URL of the MCP endpoint, for the snippet.
+ * @returns The token management panel.
+ */
+export function TokenManager({
+  tokens,
+  serverUrl,
+}: {
+  tokens: McpTokenRecord[];
+  serverUrl: string;
+}) {
+  const [name, setName] = useState('');
+  const [freshToken, setFreshToken] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const { toast } = useToast();
+
+  const copy = async (value: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast({ title: `${label} copied to clipboard.` });
+    } catch {
+      toast({
+        title: `Could not copy ${label.toLowerCase()}.`,
+        description: 'Select the text and copy it manually.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleCreate = () => {
+    startTransition(async () => {
+      const result = await createMcpToken(name);
+
+      if ('error' in result) {
+        toast({
+          title: 'Could not create token.',
+          description: result.error,
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      setFreshToken(result.token);
+      setName('');
+    });
+  };
+
+  const handleRevoke = (token: McpTokenRecord) => {
+    startTransition(async () => {
+      const result = await revokeMcpToken(token.id);
+
+      if ('error' in result) {
+        toast({
+          title: 'Could not revoke token.',
+          description: result.error,
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      toast({ title: `Revoked "${token.name}".` });
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Create an access token</CardTitle>
+          <CardDescription>
+            Your MCP client authenticates with this token. It is shown once —
+            store it somewhere safe.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="token-name">Token name</Label>
+              <Input
+                id="token-name"
+                placeholder="Claude Desktop (laptop)"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                disabled={isPending}
+              />
+            </div>
+            <Button onClick={handleCreate} disabled={isPending}>
+              <KeyRound className="mr-2 h-4 w-4" />
+              Create token
+            </Button>
+          </div>
+
+          {freshToken && (
+            <div className="space-y-3 rounded-md border border-primary/40 bg-primary/5 p-4">
+              <p className="text-sm font-medium">
+                Copy your token now — you won&apos;t be able to see it again.
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 overflow-x-auto rounded bg-muted px-3 py-2 font-mono text-xs">
+                  {freshToken}
+                </code>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => copy(freshToken, 'Token')}
+                  aria-label="Copy token"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Active tokens</CardTitle>
+          <CardDescription>
+            Revoking a token immediately cuts off any client using it.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {tokens.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No tokens yet. Create one above to connect a client.
+            </p>
+          ) : (
+            <ul className="divide-y">
+              {tokens.map((token) => (
+                <li
+                  key={token.id}
+                  className="flex flex-wrap items-center justify-between gap-3 py-3"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{token.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      <code className="font-mono">{token.token_prefix}…</code>
+                      {' · created '}
+                      {formatDate(token.created_at)}
+                      {' · last used '}
+                      {formatDate(token.last_used_at)}
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRevoke(token)}
+                    disabled={isPending}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Revoke
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Connect a client</CardTitle>
+          <CardDescription>
+            Point any MCP client at the endpoint below, replacing
+            <code className="mx-1 font-mono">YOUR_TOKEN</code>with the token you
+            created.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>Claude Code</Label>
+            <div className="flex items-start gap-2">
+              <pre className="flex-1 overflow-x-auto rounded bg-muted p-3 font-mono text-xs">
+                {`claude mcp add --transport http roster-loom ${serverUrl} \\\n  --header "Authorization: Bearer YOUR_TOKEN"`}
+              </pre>
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Copy Claude Code command"
+                onClick={() =>
+                  copy(
+                    `claude mcp add --transport http roster-loom ${serverUrl} --header "Authorization: Bearer YOUR_TOKEN"`,
+                    'Command',
+                  )
+                }
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>claude_desktop_config.json</Label>
+            <pre className="overflow-x-auto rounded bg-muted p-3 font-mono text-xs">
+              {JSON.stringify(
+                {
+                  mcpServers: {
+                    'roster-loom': {
+                      type: 'http',
+                      url: serverUrl,
+                      headers: { Authorization: 'Bearer YOUR_TOKEN' },
+                    },
+                  },
+                },
+                null,
+                2,
+              )}
+            </pre>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/mcp/page.tsx
+++ b/apps/web/src/app/(dashboard)/mcp/page.tsx
@@ -1,0 +1,100 @@
+import { headers } from 'next/headers';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+
+import { AppNavigation } from '@/components/app-navigation';
+import { MCP_TOOLS } from '@/lib/mcp/tools';
+import { createClient } from '@/utils/supabase/server';
+
+import { listMcpTokens } from './actions';
+import { TokenManager } from './components';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Resolves the absolute URL of the MCP endpoint for the running
+ * deployment, so the copy-paste snippets are correct in local dev,
+ * preview and production alike.
+ */
+async function resolveServerUrl(): Promise<string> {
+  const headerList = await headers();
+  const host = headerList.get('host');
+
+  if (!host) {
+    return '/api/mcp';
+  }
+
+  const forwardedProto = headerList.get('x-forwarded-proto');
+  const protocol =
+    forwardedProto?.split(',')[0]?.trim() ||
+    (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https');
+
+  return `${protocol}://${host}/api/mcp`;
+}
+
+/**
+ * The MCP server page: mint and revoke access tokens, and see what the
+ * server exposes.
+ */
+export default async function McpPage() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const result = await listMcpTokens();
+  const tokens = 'tokens' in result ? result.tokens : [];
+  const error = 'error' in result ? result.error : null;
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex-1 overflow-y-auto">
+        <div className="container mx-auto max-w-4xl space-y-6 p-4 sm:p-6 md:p-8">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold">MCP Server</h1>
+            <p className="text-muted-foreground">
+              Give an AI assistant read-only access to your leagues, rosters and
+              live matchups. See{' '}
+              <Link
+                href="https://modelcontextprotocol.io"
+                className="underline underline-offset-4"
+                target="_blank"
+                rel="noreferrer"
+              >
+                modelcontextprotocol.io
+              </Link>{' '}
+              for compatible clients.
+            </p>
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          <TokenManager tokens={tokens} serverUrl={await resolveServerUrl()} />
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold">Available tools</h2>
+            <ul className="space-y-2">
+              {MCP_TOOLS.map((tool) => (
+                <li key={tool.name} className="rounded-md border p-3">
+                  <p className="font-mono text-sm font-medium">{tool.name}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {tool.description}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -563,6 +563,13 @@ export async function buildSleeperTeams(
     teams.push({
       id: league.id,
       name: userName,
+      league: {
+        provider: 'sleeper',
+        providerLeagueId: league.league_id,
+        name: league.name || `Sleeper league ${league.league_id}`,
+        season: league.season ?? null,
+        totalRosters: league.total_rosters ?? null,
+      },
       totalScore: userMatchup.points,
       players: userPlayers,
       opponent: {
@@ -581,6 +588,59 @@ type BuildYahooTeamsOptions = {
   accessToken?: string;
   prefetchedTeams?: any[];
 };
+
+type YahooLeagueRow = {
+  league_id: string;
+  name: string | null;
+  season: string | null;
+  total_rosters: number | null;
+};
+
+/**
+ * Loads the persisted league rows for a Yahoo integration, keyed by
+ * league key, so teams can be labelled with their league's name.
+ *
+ * Failures are non-fatal: callers fall back to the bare league key.
+ *
+ * @param integrationId - The Yahoo integration's id.
+ * @returns A map from Yahoo league key to the stored league row.
+ */
+async function loadYahooLeagueLookup(
+  integrationId: number
+): Promise<Map<string, YahooLeagueRow>> {
+  const lookupStart = startTimer();
+
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('fp_leagues')
+      .select('league_id, name, season, total_rosters')
+      .eq('user_integration_id', integrationId);
+
+    logDuration('buildYahooTeams: load league names', lookupStart, {
+      integrationId,
+      leagueCount: data?.length ?? 0,
+      success: !error,
+    });
+
+    if (error || !data) {
+      return new Map();
+    }
+
+    return new Map(
+      data
+        .filter((row): row is YahooLeagueRow => Boolean(row?.league_id))
+        .map((row) => [row.league_id, row])
+    );
+  } catch (error) {
+    logDuration('buildYahooTeams: load league names', lookupStart, {
+      integrationId,
+      success: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    return new Map();
+  }
+}
 
 /**
  * Builds teams for a Yahoo integration.
@@ -669,6 +729,11 @@ export async function buildYahooTeams(
 
   const teams: Team[] = [];
   const resolveSleeperId = createSleeperIdResolver(playerNameMap);
+
+  // Yahoo's team payload carries only a league_key, not the league's
+  // name. Names were persisted to fp_leagues at connect time, so resolve
+  // them in one indexed query rather than per team.
+  const leagueLookup = await loadYahooLeagueLookup(integration.id);
 
   const mapYahooPlayer = (
     player: any,
@@ -808,9 +873,18 @@ export async function buildYahooTeams(
       mapYahooPlayer(p, opponentScoresMap)
     );
 
+    const leagueRow = team.league_id ? leagueLookup.get(team.league_id) : undefined;
+
     return {
       id: team.id,
       name: userTeam.name,
+      league: {
+        provider: 'yahoo',
+        providerLeagueId: team.league_id ?? '',
+        name: leagueRow?.name || `Yahoo league ${team.league_id ?? 'unknown'}`,
+        season: leagueRow?.season ?? null,
+        totalRosters: leagueRow?.total_rosters ?? null,
+      },
       totalScore: parseFloat(userTeam.totalPoints) || 0,
       players: mappedUserPlayers,
       opponent: {
@@ -1034,6 +1108,13 @@ export async function buildOttoneuTeams(
     {
       id: Number.isNaN(teamId) ? 0 : teamId,
       name: info.teamName,
+      league: {
+        provider: 'ottoneu',
+        providerLeagueId: String(league.league_id),
+        name: league.name || `Ottoneu league ${league.league_id}`,
+        season: league.season ?? null,
+        totalRosters: league.total_rosters ?? null,
+      },
       totalScore: info.matchup?.teamScore ?? 0,
       players: userPlayers,
       opponent: {

--- a/apps/web/src/app/api/mcp/route.ts
+++ b/apps/web/src/app/api/mcp/route.ts
@@ -1,0 +1,173 @@
+/**
+ * The hosted MCP server endpoint.
+ *
+ * Speaks MCP's Streamable HTTP transport statelessly: one POST carries a
+ * JSON-RPC message, one response carries the answer. There is no SSE
+ * stream and no session id, because the server never initiates messages
+ * and holds nothing between requests — which is what lets it run on
+ * serverless hosting alongside the rest of the app.
+ *
+ * Auth is a personal access token minted at /mcp and presented as
+ * `Authorization: Bearer rl_mcp_...`; see docs/MCP.md.
+ */
+import { NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+import { getCurrentNflWeek, getTeams } from '@/app/actions';
+import { DEMO_HEADER, resolveDemoMode } from '@/lib/demo-mode';
+import { dispatchMcpPayload, SUPPORTED_PROTOCOL_VERSIONS } from '@/lib/mcp/protocol';
+import type { McpToolContext } from '@/lib/mcp/tools';
+import { parseBearerToken, resolveMcpTokenUser } from '@/lib/mcp/tokens';
+import { logDuration, startTimer } from '@/utils/performance-logger';
+
+export const dynamic = 'force-dynamic';
+
+/** Advertised so clients know which auth scheme to use on a 401. */
+const AUTH_CHALLENGE = 'Bearer realm="Roster Loom MCP", error="invalid_token"';
+
+/**
+ * Supabase client for MCP requests.
+ *
+ * Prefers the service role key when configured, since MCP callers
+ * authenticate with their own token rather than a Supabase session and
+ * so carry no `auth.uid()`. Falls back to the anon key, which matches
+ * how the existing bearer-authenticated `/api/teams/refresh` path
+ * queries. Either way every query is explicitly scoped by user id.
+ */
+function createMcpSupabaseClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
+  );
+}
+
+function jsonResponse(body: unknown, status: number, protocolVersion: string) {
+  return NextResponse.json(body, {
+    status,
+    headers: { 'MCP-Protocol-Version': protocolVersion },
+  });
+}
+
+/**
+ * Handles an MCP JSON-RPC message.
+ *
+ * @param request - The incoming POST.
+ * @returns The JSON-RPC response.
+ */
+export async function POST(request: Request) {
+  const overallStart = startTimer();
+
+  const requestedVersion = request.headers.get('mcp-protocol-version');
+  const protocolVersion =
+    requestedVersion && SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion)
+      ? requestedVersion
+      : SUPPORTED_PROTOCOL_VERSIONS[0];
+
+  const token = parseBearerToken(request.headers.get('authorization'));
+  if (!token) {
+    return NextResponse.json(
+      { error: 'Missing bearer token. Create one at /mcp.' },
+      { status: 401, headers: { 'WWW-Authenticate': AUTH_CHALLENGE } },
+    );
+  }
+
+  const supabase = createMcpSupabaseClient();
+
+  const authStart = startTimer();
+  const userId = await resolveMcpTokenUser(supabase, token);
+  logDuration('mcp: authenticate token', authStart, { authenticated: Boolean(userId) });
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'Invalid or revoked token.' },
+      { status: 401, headers: { 'WWW-Authenticate': AUTH_CHALLENGE } },
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonResponse(
+      {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Request body is not valid JSON.' },
+      },
+      400,
+      protocolVersion,
+    );
+  }
+
+  const demo = resolveDemoMode({ headerValue: request.headers.get(DEMO_HEADER) });
+
+  // Invoked only when a tool actually needs data — the
+  // initialize/tools/list handshake must not fan out to the fantasy
+  // providers. `dispatchMcpPayload` guarantees at most one call.
+  const loadContext = async (): Promise<McpToolContext> => {
+    const dataStart = startTimer();
+
+    const [teamsResult, week] = await Promise.all([
+      getTeams(supabase, userId, { demo }),
+      getCurrentNflWeek().catch(() => null),
+    ]);
+
+    if ('error' in teamsResult) {
+      logDuration('mcp: load teams', dataStart, { success: false });
+      throw new Error(teamsResult.error);
+    }
+
+    logDuration('mcp: load teams', dataStart, {
+      success: true,
+      teamCount: teamsResult.teams.length,
+    });
+
+    return {
+      teams: teamsResult.teams,
+      week: typeof week === 'number' ? week : null,
+      demo,
+    };
+  };
+
+  const { status, body } = await dispatchMcpPayload(payload, loadContext);
+
+  logDuration('mcp request total', overallStart, { status });
+
+  if (body === null) {
+    return new NextResponse(null, {
+      status,
+      headers: { 'MCP-Protocol-Version': protocolVersion },
+    });
+  }
+
+  return jsonResponse(body, status, protocolVersion);
+}
+
+/**
+ * Streamable HTTP allows clients to open a GET stream for
+ * server-initiated messages. This server never sends any, so the stream
+ * is declined per spec.
+ */
+export async function GET() {
+  return NextResponse.json(
+    { error: 'This MCP server does not offer a server-initiated event stream.' },
+    { status: 405, headers: { Allow: 'POST' } },
+  );
+}
+
+/**
+ * Session termination is a no-op: the server is stateless, so there is
+ * never a session to delete.
+ */
+export async function DELETE() {
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/web/src/components/app-navigation.tsx
+++ b/apps/web/src/components/app-navigation.tsx
@@ -13,6 +13,7 @@ const NAV_LINKS = [
   { href: '/', label: 'Dashboard' },
   { href: '/matchup-report', label: 'Matchup Report' },
   { href: '/integrations', label: 'Integrations' },
+  { href: '/mcp', label: 'MCP Server' },
 ];
 
 /**

--- a/apps/web/src/lib/mcp/protocol.test.ts
+++ b/apps/web/src/lib/mcp/protocol.test.ts
@@ -1,0 +1,218 @@
+import type { Team } from '@roster-loom/core';
+
+import {
+  DEFAULT_PROTOCOL_VERSION,
+  dispatchMcpPayload,
+  JSON_RPC_ERRORS,
+  negotiateProtocolVersion,
+} from './protocol';
+import type { McpToolContext } from './tools';
+
+const team: Team = {
+  id: 1,
+  name: 'My Team',
+  league: {
+    provider: 'sleeper',
+    providerLeagueId: '99',
+    name: 'Test League',
+    season: '2026',
+    totalRosters: 10,
+  },
+  totalScore: 100,
+  players: [
+    {
+      id: 'p1',
+      name: 'Star Player',
+      position: 'WR',
+      realTeam: 'SF',
+      score: 22.4,
+      gameStatus: 'final',
+      gameStartTime: null,
+      gameQuarter: 'Final',
+      gameClock: null,
+      onUserTeams: 0,
+      onOpponentTeams: 0,
+      gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
+      imageUrl: '',
+      onBench: false,
+    },
+  ],
+  opponent: { name: 'Their Team', totalScore: 88, players: [] },
+};
+
+function contextLoader(overrides: Partial<McpToolContext> = {}) {
+  const load = jest.fn(async (): Promise<McpToolContext> => ({
+    teams: [team],
+    week: 5,
+    demo: false,
+    ...overrides,
+  }));
+
+  return load;
+}
+
+async function call(payload: unknown, load = contextLoader()) {
+  return dispatchMcpPayload(payload, load);
+}
+
+describe('negotiateProtocolVersion', () => {
+  it('echoes a supported version', () => {
+    expect(negotiateProtocolVersion('2024-11-05')).toBe('2024-11-05');
+  });
+
+  it('falls back to the newest for anything else', () => {
+    expect(negotiateProtocolVersion('1999-01-01')).toBe(DEFAULT_PROTOCOL_VERSION);
+    expect(negotiateProtocolVersion(undefined)).toBe(DEFAULT_PROTOCOL_VERSION);
+  });
+});
+
+describe('initialize', () => {
+  it('advertises tool support and identifies the server', async () => {
+    const { status, body } = await call({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26' },
+    });
+
+    expect(status).toBe(200);
+    const result = (body as any).result;
+    expect(result.protocolVersion).toBe('2025-03-26');
+    expect(result.capabilities.tools).toBeDefined();
+    expect(result.serverInfo.name).toBe('roster-loom');
+    expect(result.instructions).toContain('list_leagues');
+  });
+
+  it('does not fetch fantasy data during the handshake', async () => {
+    const load = contextLoader();
+
+    await call({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }, load);
+    await call({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, load);
+
+    expect(load).not.toHaveBeenCalled();
+  });
+});
+
+describe('notifications', () => {
+  it('are acknowledged with 202 and no body', async () => {
+    const { status, body } = await call({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+
+    expect(status).toBe(202);
+    expect(body).toBeNull();
+  });
+});
+
+describe('tools/list', () => {
+  it('returns every tool with an input schema', async () => {
+    const { body } = await call({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+    const tools = (body as any).result.tools;
+
+    expect(tools.length).toBeGreaterThan(0);
+    expect(tools.map((tool: any) => tool.name)).toContain('list_leagues');
+    for (const tool of tools) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(typeof tool.description).toBe('string');
+    }
+  });
+});
+
+describe('tools/call', () => {
+  it('runs a tool and returns text plus structured content', async () => {
+    const { body } = await call({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'list_leagues', arguments: {} },
+    });
+
+    const result = (body as any).result;
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent.leagueCount).toBe(1);
+    expect(result.structuredContent.leagues[0].leagueKey).toBe('sleeper:99');
+    expect(JSON.parse(result.content[0].text).week).toBe(5);
+  });
+
+  it('loads fantasy data at most once per request', async () => {
+    const load = contextLoader();
+
+    await call(
+      [
+        { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'list_leagues' } },
+        { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'get_rooting_guide' } },
+      ],
+      load,
+    );
+
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports an unknown tool as invalid params', async () => {
+    const { body } = await call({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'nope' },
+    });
+
+    expect((body as any).error.code).toBe(JSON_RPC_ERRORS.invalidParams);
+  });
+
+  it('returns a tool error, not a protocol error, for a bad league key', async () => {
+    const { body } = await call({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'get_league_matchup', arguments: { leagueKey: 'missing' } },
+    });
+
+    const result = (body as any).result;
+    expect(result.isError).toBe(true);
+    // The model should be told what it could have used instead.
+    expect(result.content[0].text).toContain('sleeper:99');
+  });
+
+  it('surfaces a data-loading failure as a tool error', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const failing = jest.fn(async () => {
+      throw new Error('Supabase exploded');
+    });
+
+    const { status, body } = await call(
+      { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'list_leagues' } },
+      failing,
+    );
+
+    expect(status).toBe(200);
+    expect((body as any).result.isError).toBe(true);
+    expect((body as any).result.content[0].text).toContain('Supabase exploded');
+
+    errorSpy.mockRestore();
+  });
+});
+
+describe('malformed input', () => {
+  it('rejects a non-object body', async () => {
+    const { status, body } = await call('nope');
+
+    expect(status).toBe(400);
+    expect((body as any).error.code).toBe(JSON_RPC_ERRORS.invalidRequest);
+  });
+
+  it('rejects an empty batch', async () => {
+    const { status } = await call([]);
+    expect(status).toBe(400);
+  });
+
+  it('reports unknown methods', async () => {
+    const { body } = await call({ jsonrpc: '2.0', id: 1, method: 'resources/list' });
+    expect((body as any).error.code).toBe(JSON_RPC_ERRORS.methodNotFound);
+  });
+
+  it('answers ping', async () => {
+    const { body } = await call({ jsonrpc: '2.0', id: 1, method: 'ping' });
+    expect((body as any).result).toEqual({});
+  });
+});

--- a/apps/web/src/lib/mcp/protocol.ts
+++ b/apps/web/src/lib/mcp/protocol.ts
@@ -1,0 +1,246 @@
+/**
+ * A minimal, stateless implementation of MCP's Streamable HTTP transport.
+ *
+ * The server is tools-only and holds no session state, so a request is
+ * fully described by its JSON-RPC body: every POST is answered with a
+ * single JSON response and nothing is retained between calls. That is
+ * exactly the shape serverless hosting wants, and it keeps the protocol
+ * surface small enough to own directly rather than pulling in an adapter
+ * that pins its own SDK version.
+ *
+ * Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+ */
+import { findTool, listToolDescriptors, type McpToolContext } from './tools';
+
+/** Protocol revisions this server understands, newest first. */
+export const SUPPORTED_PROTOCOL_VERSIONS = [
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05',
+];
+
+/** The revision used when a client doesn't ask for a specific one. */
+export const DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+const SERVER_INFO = {
+  name: 'roster-loom',
+  title: 'Roster Loom',
+  version: '1.0.0',
+};
+
+const INSTRUCTIONS = [
+  'Roster Loom aggregates one user’s fantasy football teams across Sleeper,',
+  'Yahoo and Ottoneu into a single live view. All data is scoped to the',
+  'account that issued the access token, and reflects the current NFL week.',
+  'Call `list_leagues` first — the `leagueKey` values it returns address',
+  'every other league-specific tool.',
+].join(' ');
+
+/** JSON-RPC error codes used by this server. */
+export const JSON_RPC_ERRORS = {
+  parseError: -32700,
+  invalidRequest: -32600,
+  methodNotFound: -32601,
+  invalidParams: -32602,
+  internalError: -32603,
+} as const;
+
+type JsonRpcId = string | number | null;
+
+type JsonRpcRequest = {
+  jsonrpc?: unknown;
+  id?: JsonRpcId;
+  method?: unknown;
+  params?: unknown;
+};
+
+type JsonRpcResponse = {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+};
+
+function success(id: JsonRpcId, result: unknown): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function failure(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, error: { code, message, ...(data ? { data } : {}) } };
+}
+
+/**
+ * Picks the protocol revision to answer an `initialize` with: the
+ * client's request when supported, otherwise this server's newest.
+ *
+ * @param requested - The `protocolVersion` the client asked for.
+ * @returns The revision to report back.
+ */
+export function negotiateProtocolVersion(requested: unknown): string {
+  return typeof requested === 'string' &&
+    SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+    ? requested
+    : DEFAULT_PROTOCOL_VERSION;
+}
+
+/**
+ * Handles one JSON-RPC message.
+ *
+ * @param message - The parsed request or notification.
+ * @param loadContext - Lazily resolves the user's teams. Only invoked
+ *   for `tools/call`, so handshake traffic never triggers a fan-out to
+ *   the fantasy providers.
+ * @returns The response, or `null` for notifications (which get no reply).
+ */
+async function handleMessage(
+  message: JsonRpcRequest,
+  loadContext: () => Promise<McpToolContext>,
+): Promise<JsonRpcResponse | null> {
+  const id = message.id ?? null;
+  const isNotification = message.id === undefined || message.id === null;
+  const method = typeof message.method === 'string' ? message.method : null;
+
+  if (!method) {
+    return isNotification
+      ? null
+      : failure(id, JSON_RPC_ERRORS.invalidRequest, 'Request is missing a method.');
+  }
+
+  // Notifications never get a reply, whatever they are.
+  if (isNotification) {
+    return null;
+  }
+
+  const params =
+    message.params && typeof message.params === 'object'
+      ? (message.params as Record<string, unknown>)
+      : {};
+
+  switch (method) {
+    case 'initialize':
+      return success(id, {
+        protocolVersion: negotiateProtocolVersion(params.protocolVersion),
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: SERVER_INFO,
+        instructions: INSTRUCTIONS,
+      });
+
+    case 'ping':
+      return success(id, {});
+
+    case 'tools/list':
+      return success(id, { tools: listToolDescriptors() });
+
+    case 'tools/call': {
+      const name = typeof params.name === 'string' ? params.name : null;
+      if (!name) {
+        return failure(
+          id,
+          JSON_RPC_ERRORS.invalidParams,
+          'tools/call requires a `name` parameter.',
+        );
+      }
+
+      const tool = findTool(name);
+      if (!tool) {
+        return failure(id, JSON_RPC_ERRORS.invalidParams, `Unknown tool: ${name}`);
+      }
+
+      const args =
+        params.arguments && typeof params.arguments === 'object'
+          ? (params.arguments as Record<string, unknown>)
+          : {};
+
+      try {
+        const context = await loadContext();
+        return success(id, tool.handler(args, context));
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        console.error(`MCP tool ${name} failed`, error);
+
+        // Surfaced as a tool error rather than a protocol error: the
+        // call was well-formed, the data behind it just wasn't there.
+        return success(id, {
+          content: [{ type: 'text', text: `Failed to load fantasy data: ${detail}` }],
+          isError: true,
+        });
+      }
+    }
+
+    default:
+      return failure(id, JSON_RPC_ERRORS.methodNotFound, `Unknown method: ${method}`);
+  }
+}
+
+/** What the transport should send back for a parsed payload. */
+export type McpDispatchResult = {
+  /** HTTP status to respond with. */
+  status: number;
+  /** Response body, or `null` when there is nothing to send (202). */
+  body: JsonRpcResponse | JsonRpcResponse[] | null;
+};
+
+/**
+ * Dispatches a decoded request body, handling both single messages and
+ * the batch arrays permitted by pre-2025-06-18 revisions.
+ *
+ * @param payload - The parsed JSON body of the POST.
+ * @param loadContext - Lazily resolves the user's teams.
+ * @returns The status and body to respond with.
+ */
+export async function dispatchMcpPayload(
+  payload: unknown,
+  loadContext: () => Promise<McpToolContext>,
+): Promise<McpDispatchResult> {
+  // Memoized here rather than by the caller so the "one provider
+  // fan-out per request" guarantee holds however the loader is written,
+  // including for batches where several tools run off one payload.
+  let pending: Promise<McpToolContext> | null = null;
+  const loadOnce = () => {
+    pending ??= loadContext();
+    return pending;
+  };
+
+  if (Array.isArray(payload)) {
+    if (payload.length === 0) {
+      return {
+        status: 400,
+        body: failure(null, JSON_RPC_ERRORS.invalidRequest, 'Batch must not be empty.'),
+      };
+    }
+
+    const responses = await Promise.all(
+      payload.map((message) => handleMessage(message ?? {}, loadOnce)),
+    );
+    const populated = responses.filter(
+      (response): response is JsonRpcResponse => response !== null,
+    );
+
+    // An all-notification batch is acknowledged with no content.
+    return populated.length === 0
+      ? { status: 202, body: null }
+      : { status: 200, body: populated };
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return {
+      status: 400,
+      body: failure(
+        null,
+        JSON_RPC_ERRORS.invalidRequest,
+        'Request body must be a JSON-RPC object or array.',
+      ),
+    };
+  }
+
+  const response = await handleMessage(payload as JsonRpcRequest, loadOnce);
+
+  return response === null
+    ? { status: 202, body: null }
+    : { status: 200, body: response };
+}

--- a/apps/web/src/lib/mcp/tokens.test.ts
+++ b/apps/web/src/lib/mcp/tokens.test.ts
@@ -4,7 +4,6 @@ import {
   mintMcpToken,
   parseBearerToken,
   resolveMcpTokenUser,
-  tokensMatch,
 } from './tokens';
 
 describe('mintMcpToken', () => {
@@ -40,17 +39,6 @@ describe('parseBearerToken', () => {
       expect(parseBearerToken(header as string | null)).toBeNull();
     },
   );
-});
-
-describe('tokensMatch', () => {
-  it('compares equal tokens', () => {
-    expect(tokensMatch('abc', 'abc')).toBe(true);
-  });
-
-  it('rejects different tokens and lengths', () => {
-    expect(tokensMatch('abc', 'abd')).toBe(false);
-    expect(tokensMatch('abc', 'abcd')).toBe(false);
-  });
 });
 
 describe('resolveMcpTokenUser', () => {

--- a/apps/web/src/lib/mcp/tokens.test.ts
+++ b/apps/web/src/lib/mcp/tokens.test.ts
@@ -1,0 +1,105 @@
+import {
+  MCP_TOKEN_PREFIX,
+  hashMcpToken,
+  mintMcpToken,
+  parseBearerToken,
+  resolveMcpTokenUser,
+  tokensMatch,
+} from './tokens';
+
+describe('mintMcpToken', () => {
+  it('produces a prefixed token with its hash and display prefix', () => {
+    const { token, tokenHash, tokenPrefix } = mintMcpToken();
+
+    expect(token.startsWith(MCP_TOKEN_PREFIX)).toBe(true);
+    expect(tokenHash).toBe(hashMcpToken(token));
+    expect(tokenHash).toHaveLength(64);
+    expect(token.startsWith(tokenPrefix)).toBe(true);
+    // The stored prefix must not be enough to reconstruct the token.
+    expect(tokenPrefix.length).toBeLessThan(token.length);
+  });
+
+  it('does not repeat', () => {
+    const tokens = new Set(Array.from({ length: 50 }, () => mintMcpToken().token));
+    expect(tokens.size).toBe(50);
+  });
+});
+
+describe('parseBearerToken', () => {
+  it.each([
+    ['Bearer abc123', 'abc123'],
+    ['bearer abc123', 'abc123'],
+    ['Bearer   abc123  ', 'abc123'],
+  ])('parses %s', (header, expected) => {
+    expect(parseBearerToken(header)).toBe(expected);
+  });
+
+  it.each([[null], [undefined], [''], ['Basic abc123'], ['Bearer'], ['Bearer   ']])(
+    'rejects %s',
+    (header) => {
+      expect(parseBearerToken(header as string | null)).toBeNull();
+    },
+  );
+});
+
+describe('tokensMatch', () => {
+  it('compares equal tokens', () => {
+    expect(tokensMatch('abc', 'abc')).toBe(true);
+  });
+
+  it('rejects different tokens and lengths', () => {
+    expect(tokensMatch('abc', 'abd')).toBe(false);
+    expect(tokensMatch('abc', 'abcd')).toBe(false);
+  });
+});
+
+describe('resolveMcpTokenUser', () => {
+  const client = (response: { data?: unknown; error?: unknown }) =>
+    ({ rpc: jest.fn().mockResolvedValue(response) }) as never;
+
+  it('returns the owning user id', async () => {
+    const supabase = client({ data: 'user-1', error: null });
+
+    await expect(resolveMcpTokenUser(supabase, `${MCP_TOKEN_PREFIX}abc`)).resolves.toBe(
+      'user-1',
+    );
+  });
+
+  it('passes the hash, never the plaintext', async () => {
+    const supabase = client({ data: 'user-1', error: null });
+    const token = `${MCP_TOKEN_PREFIX}secret`;
+
+    await resolveMcpTokenUser(supabase, token);
+
+    expect((supabase as never as { rpc: jest.Mock }).rpc).toHaveBeenCalledWith(
+      'fp_mcp_token_owner',
+      { p_token_hash: hashMcpToken(token) },
+    );
+  });
+
+  it('rejects tokens without the expected prefix without querying', async () => {
+    const supabase = client({ data: 'user-1', error: null });
+
+    await expect(resolveMcpTokenUser(supabase, 'some-other-token')).resolves.toBeNull();
+    expect((supabase as never as { rpc: jest.Mock }).rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the token is unknown or revoked', async () => {
+    const supabase = client({ data: null, error: null });
+
+    await expect(
+      resolveMcpTokenUser(supabase, `${MCP_TOKEN_PREFIX}abc`),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null on a database error', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const supabase = client({ data: null, error: { message: 'boom' } });
+
+    await expect(
+      resolveMcpTokenUser(supabase, `${MCP_TOKEN_PREFIX}abc`),
+    ).resolves.toBeNull();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/lib/mcp/tokens.ts
+++ b/apps/web/src/lib/mcp/tokens.ts
@@ -1,0 +1,121 @@
+/**
+ * Minting and verification of MCP personal access tokens.
+ *
+ * The plaintext token is returned to the user exactly once (at creation);
+ * only its SHA-256 lands in `fp_mcp_tokens`. Verification hashes the
+ * presented token and asks Postgres to resolve the owner via the
+ * `fp_mcp_token_owner` SECURITY DEFINER function, which also stamps
+ * `last_used_at`.
+ */
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Prefix every token carries, so leaked strings are recognisable. */
+export const MCP_TOKEN_PREFIX = 'rl_mcp_';
+
+/** Bytes of entropy behind each token. */
+const TOKEN_ENTROPY_BYTES = 32;
+
+/** How much of the plaintext we keep for display (`rl_mcp_abcd1234…`). */
+const DISPLAY_PREFIX_LENGTH = MCP_TOKEN_PREFIX.length + 8;
+
+/** A freshly minted token: plaintext (shown once) plus what to persist. */
+export type MintedToken = {
+  /** Full plaintext token. Never stored. */
+  token: string;
+  /** SHA-256 of the plaintext, hex encoded. */
+  tokenHash: string;
+  /** Leading characters of the plaintext, safe to display later. */
+  tokenPrefix: string;
+};
+
+/**
+ * Hashes a token the same way stored hashes were produced.
+ *
+ * @param token - The plaintext token.
+ * @returns Hex-encoded SHA-256 of the token.
+ */
+export function hashMcpToken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+/**
+ * Generates a new token with 256 bits of entropy.
+ *
+ * @returns The plaintext token alongside the values to persist.
+ */
+export function mintMcpToken(): MintedToken {
+  const token = `${MCP_TOKEN_PREFIX}${randomBytes(TOKEN_ENTROPY_BYTES).toString('base64url')}`;
+
+  return {
+    token,
+    tokenHash: hashMcpToken(token),
+    tokenPrefix: token.slice(0, DISPLAY_PREFIX_LENGTH),
+  };
+}
+
+/**
+ * Extracts a bearer token from an `Authorization` header.
+ *
+ * @param header - The raw header value, if any.
+ * @returns The token, or `null` when the header is absent or not bearer.
+ */
+export function parseBearerToken(header: string | null | undefined): string | null {
+  if (!header) {
+    return null;
+  }
+
+  const match = header.match(/^bearer\s+(.+)$/i);
+  const token = match?.[1]?.trim();
+
+  return token ? token : null;
+}
+
+/**
+ * Constant-time comparison of two tokens, used where a caller needs to
+ * compare a presented token against a known one without leaking length
+ * information through early exit.
+ *
+ * @param a - First token.
+ * @param b - Second token.
+ * @returns Whether the tokens are identical.
+ */
+export function tokensMatch(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a, 'utf8');
+  const bufferB = Buffer.from(b, 'utf8');
+
+  if (bufferA.length !== bufferB.length) {
+    return false;
+  }
+
+  return timingSafeEqual(bufferA, bufferB);
+}
+
+/**
+ * Resolves the user a token belongs to.
+ *
+ * @param client - Supabase client (anon key is sufficient — the RPC is
+ *   SECURITY DEFINER).
+ * @param token - The plaintext token presented by the caller.
+ * @returns The owning user id, or `null` when the token is unknown,
+ *   revoked, or malformed.
+ */
+export async function resolveMcpTokenUser(
+  client: SupabaseClient,
+  token: string,
+): Promise<string | null> {
+  if (!token.startsWith(MCP_TOKEN_PREFIX)) {
+    return null;
+  }
+
+  const { data, error } = await client.rpc('fp_mcp_token_owner', {
+    p_token_hash: hashMcpToken(token),
+  });
+
+  if (error) {
+    console.error('Failed to resolve MCP token', error.message);
+    return null;
+  }
+
+  return typeof data === 'string' && data ? data : null;
+}

--- a/apps/web/src/lib/mcp/tokens.ts
+++ b/apps/web/src/lib/mcp/tokens.ts
@@ -7,7 +7,7 @@
  * `fp_mcp_token_owner` SECURITY DEFINER function, which also stamps
  * `last_used_at`.
  */
-import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 /** Prefix every token carries, so leaked strings are recognisable. */
@@ -69,26 +69,6 @@ export function parseBearerToken(header: string | null | undefined): string | nu
   const token = match?.[1]?.trim();
 
   return token ? token : null;
-}
-
-/**
- * Constant-time comparison of two tokens, used where a caller needs to
- * compare a presented token against a known one without leaking length
- * information through early exit.
- *
- * @param a - First token.
- * @param b - Second token.
- * @returns Whether the tokens are identical.
- */
-export function tokensMatch(a: string, b: string): boolean {
-  const bufferA = Buffer.from(a, 'utf8');
-  const bufferB = Buffer.from(b, 'utf8');
-
-  if (bufferA.length !== bufferB.length) {
-    return false;
-  }
-
-  return timingSafeEqual(bufferA, bufferB);
 }
 
 /**

--- a/apps/web/src/lib/mcp/tools.test.ts
+++ b/apps/web/src/lib/mcp/tools.test.ts
@@ -1,0 +1,188 @@
+/**
+ * End-to-end coverage of the tools over real generated data, so the
+ * league metadata the builders attach is exercised rather than mocked.
+ */
+import { generateDemoTeams } from '@roster-loom/core';
+
+import { dispatchMcpPayload } from './protocol';
+import { findTool, listToolDescriptors, MCP_TOOLS, type McpToolContext } from './tools';
+
+const context: McpToolContext = {
+  teams: generateDemoTeams(Date.parse('2026-09-13T17:30:00Z')),
+  week: 2,
+  demo: true,
+};
+
+const run = (name: string, args: Record<string, unknown> = {}) => {
+  const tool = findTool(name);
+  if (!tool) {
+    throw new Error(`Unknown tool: ${name}`);
+  }
+
+  const result = tool.handler(args, context);
+
+  return {
+    result,
+    payload: result.structuredContent as Record<string, any>,
+  };
+};
+
+describe('tool definitions', () => {
+  it('exposes unique names', () => {
+    const names = MCP_TOOLS.map((tool) => tool.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('documents every tool and marks required arguments', () => {
+    for (const tool of listToolDescriptors()) {
+      expect(tool.description.length).toBeGreaterThan(40);
+      expect(tool.title).toBeTruthy();
+
+      for (const required of tool.inputSchema.required ?? []) {
+        expect(tool.inputSchema.properties).toHaveProperty(required);
+      }
+    }
+  });
+});
+
+describe('list_leagues over demo data', () => {
+  it('returns one entry per league with a usable key', () => {
+    const { payload } = run('list_leagues');
+
+    expect(payload.leagueCount).toBe(context.teams.length);
+    expect(payload.demoMode).toBe(true);
+    expect(payload.week).toBe(2);
+
+    for (const league of payload.leagues) {
+      expect(league.leagueKey).toMatch(/^demo:/);
+      expect(league.leagueName).toBeTruthy();
+      // The reported margin must reconcile with the two scores.
+      expect(league.margin).toBeCloseTo(league.points - league.opponentPoints, 5);
+    }
+  });
+
+  it('counts leading and trailing leagues consistently', () => {
+    const { payload } = run('list_leagues');
+
+    expect(payload.leadingCount + payload.trailingCount).toBeLessThanOrEqual(
+      payload.leagueCount,
+    );
+  });
+});
+
+describe('get_league_matchup over demo data', () => {
+  it('returns both full rosters for a key from list_leagues', () => {
+    const { payload: leagues } = run('list_leagues');
+    const { leagueKey } = leagues.leagues[0];
+
+    const { result, payload } = run('get_league_matchup', { leagueKey });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.leagueKey).toBe(leagueKey);
+    expect(payload.you.starters.length).toBeGreaterThan(0);
+    expect(payload.you.bench.length).toBeGreaterThan(0);
+    expect(payload.opponent.starters.length).toBeGreaterThan(0);
+    expect(payload.you.starters.every((p: any) => p.starting)).toBe(true);
+    expect(payload.you.bench.every((p: any) => !p.starting)).toBe(true);
+  });
+
+  it('errors without a league key', () => {
+    expect(run('get_league_matchup', {}).result.isError).toBe(true);
+  });
+});
+
+describe('list_rostered_players over demo data', () => {
+  it('only reports players the user actually rosters', () => {
+    const { payload } = run('list_rostered_players');
+
+    expect(payload.playerCount).toBeGreaterThan(0);
+    for (const player of payload.players) {
+      expect(player.onYourTeams).toBeGreaterThan(0);
+      expect(player.rosteredIn.length).toBe(player.onYourTeams);
+    }
+  });
+
+  it('filters by position', () => {
+    const { payload } = run('list_rostered_players', { position: 'qb' });
+
+    expect(payload.players.length).toBeGreaterThan(0);
+    expect(payload.players.every((p: any) => p.position === 'QB')).toBe(true);
+  });
+
+  it('filters to multi-league players only', () => {
+    const { payload } = run('list_rostered_players', { onlyMultiLeague: true });
+
+    expect(payload.players.every((p: any) => p.onYourTeams >= 2)).toBe(true);
+  });
+
+  it('filters to players starting somewhere', () => {
+    const { payload } = run('list_rostered_players', { onlyStarters: true });
+
+    expect(
+      payload.players.every((p: any) => p.rosteredIn.some((r: any) => r.starting)),
+    ).toBe(true);
+  });
+});
+
+describe('find_player over demo data', () => {
+  it('finds a known player from the demo pool', () => {
+    const { payload: all } = run('list_rostered_players');
+    const target = all.players[0].name;
+
+    const { payload } = run('find_player', { query: target.split(' ')[1] ?? target });
+
+    expect(payload.matchCount).toBeGreaterThan(0);
+    expect(payload.players.some((p: any) => p.name === target)).toBe(true);
+  });
+
+  it('returns an empty match set rather than an error for a miss', () => {
+    const { result, payload } = run('find_player', { query: 'zzzznotaplayer' });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.matchCount).toBe(0);
+  });
+
+  it('errors on a blank query', () => {
+    expect(run('find_player', { query: '  ' }).result.isError).toBe(true);
+  });
+});
+
+describe('get_rooting_guide over demo data', () => {
+  it('classifies players into the three buckets', () => {
+    const { payload } = run('get_rooting_guide');
+
+    expect(Array.isArray(payload.rootFor)).toBe(true);
+    expect(Array.isArray(payload.rootAgainst)).toBe(true);
+    expect(Array.isArray(payload.conflicted)).toBe(true);
+    // The demo slate deliberately overlaps rosters.
+    expect(payload.rootFor.length + payload.conflicted.length).toBeGreaterThan(0);
+  });
+});
+
+describe('every tool over the wire', () => {
+  it('returns parseable JSON text matching its structured content', async () => {
+    for (const tool of MCP_TOOLS) {
+      const { body } = await dispatchMcpPayload(
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: tool.name,
+            arguments:
+              tool.name === 'get_league_matchup'
+                ? { leagueKey: 'demo:demo-league-1' }
+                : tool.name === 'find_player'
+                  ? { query: 'a' }
+                  : {},
+          },
+        },
+        async () => context,
+      );
+
+      const result = (body as any).result;
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0].text)).toEqual(result.structuredContent);
+    }
+  });
+});

--- a/apps/web/src/lib/mcp/tools.ts
+++ b/apps/web/src/lib/mcp/tools.ts
@@ -1,0 +1,297 @@
+/**
+ * The tools the Roster Loom MCP server exposes.
+ *
+ * Each tool is a pure function of the already-fetched `Team[]` plus its
+ * arguments, so the route handler does exactly one provider fan-out per
+ * request no matter which tool was called.
+ */
+import type { Team } from '@roster-loom/core';
+import {
+  aggregatePlayerExposure,
+  buildRootingGuide,
+  describeMatchup,
+  findTeamByLeagueKey,
+  searchPlayerExposure,
+  summarizeLeagues,
+  type McpPlayerExposure,
+} from './views';
+
+/** Everything a tool needs about the current request. */
+export type McpToolContext = {
+  /** The user's teams across every connected provider. */
+  teams: Team[];
+  /** The NFL week the scores belong to. */
+  week: number | null;
+  /** Whether the data is demo data rather than live provider data. */
+  demo: boolean;
+};
+
+/** What a tool hands back to the transport layer. */
+export type McpToolResult = {
+  content: { type: 'text'; text: string }[];
+  structuredContent?: unknown;
+  isError?: boolean;
+};
+
+type JsonSchema = {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+};
+
+/** A tool's public description plus its implementation. */
+export type McpTool = {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: JsonSchema;
+  handler: (
+    args: Record<string, unknown>,
+    context: McpToolContext,
+  ) => McpToolResult;
+};
+
+const EMPTY_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+};
+
+/**
+ * Wraps a payload in the dual representation MCP clients expect: JSON
+ * text for models that read the transcript, and `structuredContent` for
+ * clients that consume tool output programmatically.
+ *
+ * @param payload - The tool's result data.
+ * @returns The MCP tool result.
+ */
+function ok(payload: unknown): McpToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+    structuredContent: payload as Record<string, unknown>,
+  };
+}
+
+/**
+ * Builds a tool-level error. These are reported through `isError` rather
+ * than a JSON-RPC error so the model can see and recover from them.
+ *
+ * @param message - What went wrong, phrased for the model.
+ * @returns The MCP tool result.
+ */
+function fail(message: string): McpToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+function readString(
+  args: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = args[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function describeContext(context: McpToolContext) {
+  return {
+    week: context.week,
+    ...(context.demo ? { demoMode: true } : {}),
+  };
+}
+
+function filterExposures(
+  exposures: McpPlayerExposure[],
+  args: Record<string, unknown>,
+): McpPlayerExposure[] {
+  const position = readString(args, 'position');
+  const onlyStarters = args.onlyStarters === true;
+  const onlyMultiLeague = args.onlyMultiLeague === true;
+
+  return exposures.filter((exposure) => {
+    if (position && exposure.position.toUpperCase() !== position.toUpperCase()) {
+      return false;
+    }
+
+    if (onlyStarters && !exposure.rosteredIn.some((entry) => entry.starting)) {
+      return false;
+    }
+
+    if (onlyMultiLeague && exposure.onYourTeams < 2) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+/** Every tool the server advertises, in the order clients see them. */
+export const MCP_TOOLS: McpTool[] = [
+  {
+    name: 'list_leagues',
+    title: 'List leagues',
+    description:
+      "Lists every fantasy football league the user has a team in, across all connected platforms (Sleeper, Yahoo, Ottoneu), with this week's score, the opponent's score, the margin, and how many starters have yet to kick off. Start here: other tools take the `leagueKey` values this returns.",
+    inputSchema: EMPTY_SCHEMA,
+    handler: (_args, context) => {
+      const leagues = summarizeLeagues(context.teams);
+
+      return ok({
+        ...describeContext(context),
+        leagueCount: leagues.length,
+        leadingCount: leagues.filter((league) => league.margin > 0).length,
+        trailingCount: leagues.filter((league) => league.margin < 0).length,
+        leagues,
+      });
+    },
+  },
+  {
+    name: 'get_league_matchup',
+    title: 'Get a league matchup',
+    description:
+      "Returns one league's full head-to-head matchup: both teams' starting lineups and benches, every player's fantasy points, their NFL team, and their live game state (kickoff time, quarter and clock, or final). Use this for detailed roster and scoring questions about a specific league.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        leagueKey: {
+          type: 'string',
+          description:
+            'The `leagueKey` from `list_leagues`. The league or team name also works.',
+        },
+      },
+      required: ['leagueKey'],
+      additionalProperties: false,
+    },
+    handler: (args, context) => {
+      const leagueKey = readString(args, 'leagueKey');
+      if (!leagueKey) {
+        return fail('`leagueKey` is required. Call `list_leagues` first to get one.');
+      }
+
+      const match = findTeamByLeagueKey(context.teams, leagueKey);
+      if (!match) {
+        const available = summarizeLeagues(context.teams)
+          .map((league) => `${league.leagueKey} (${league.leagueName})`)
+          .join(', ');
+
+        return fail(
+          available
+            ? `No league matched "${leagueKey}". Available leagues: ${available}.`
+            : `No league matched "${leagueKey}". This account has no connected leagues.`,
+        );
+      }
+
+      return ok({
+        ...describeContext(context),
+        ...describeMatchup(match.team, match.leagueKey),
+      });
+    },
+  },
+  {
+    name: 'list_rostered_players',
+    title: 'List players across all leagues',
+    description:
+      "Aggregates every player across all of the user's leagues at once, deduplicated by player. For each one it reports the leagues where the user rosters them (and whether they're starting), the leagues where the opponent rosters them, and their current points. Use this for cross-league questions like exposure, double-ups, or who is starting where.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        position: {
+          type: 'string',
+          description: 'Restrict to a single position, e.g. `QB`, `RB`, `WR`, `TE`.',
+        },
+        onlyStarters: {
+          type: 'boolean',
+          description: 'Only include players starting in at least one of the user’s leagues.',
+        },
+        onlyMultiLeague: {
+          type: 'boolean',
+          description: 'Only include players the user rosters in two or more leagues.',
+        },
+      },
+      additionalProperties: false,
+    },
+    handler: (args, context) => {
+      const all = aggregatePlayerExposure(context.teams);
+      const players = filterExposures(all, args).filter(
+        (exposure) => exposure.onYourTeams > 0,
+      );
+
+      return ok({
+        ...describeContext(context),
+        playerCount: players.length,
+        players,
+      });
+    },
+  },
+  {
+    name: 'find_player',
+    title: 'Find a player',
+    description:
+      "Searches every roster in every league — the user's teams and their opponents' — for a player by name or NFL team abbreviation. Returns where the player shows up, whether they're starting, their points, and their live game state. Use this to answer 'do I have X anywhere' or 'who is starting against me'.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Part of a player name (e.g. `mahomes`) or an NFL team abbreviation (e.g. `KC`).',
+        },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    handler: (args, context) => {
+      const query = readString(args, 'query');
+      if (!query) {
+        return fail('`query` is required — pass part of a player name or an NFL team abbreviation.');
+      }
+
+      const matches = searchPlayerExposure(aggregatePlayerExposure(context.teams), query);
+
+      return ok({
+        ...describeContext(context),
+        query,
+        matchCount: matches.length,
+        players: matches,
+      });
+    },
+  },
+  {
+    name: 'get_rooting_guide',
+    title: 'Get the cross-league rooting guide',
+    description:
+      "Classifies players across the user's whole slate into who to root for (on multiple of the user's teams, no opponent's), who to root against (on multiple opponent teams), and who they're conflicted about (on both sides). Use this for 'who should I be cheering for this week' questions.",
+    inputSchema: EMPTY_SCHEMA,
+    handler: (_args, context) =>
+      ok({
+        ...describeContext(context),
+        ...buildRootingGuide(context.teams),
+      }),
+  },
+];
+
+/**
+ * Looks a tool up by name.
+ *
+ * @param name - The tool name from a `tools/call` request.
+ * @returns The tool, or `undefined` when unknown.
+ */
+export function findTool(name: string): McpTool | undefined {
+  return MCP_TOOLS.find((tool) => tool.name === name);
+}
+
+/**
+ * The tool list in the shape `tools/list` returns.
+ *
+ * @returns Tool descriptors without their handlers.
+ */
+export function listToolDescriptors() {
+  return MCP_TOOLS.map(({ name, title, description, inputSchema }) => ({
+    name,
+    title,
+    description,
+    inputSchema,
+  }));
+}

--- a/apps/web/src/lib/mcp/views.test.ts
+++ b/apps/web/src/lib/mcp/views.test.ts
@@ -1,0 +1,289 @@
+import type { Player, Team } from '@roster-loom/core';
+
+import {
+  aggregatePlayerExposure,
+  buildRootingGuide,
+  describeMatchup,
+  findTeamByLeagueKey,
+  leagueKeyFor,
+  searchPlayerExposure,
+  summarizeLeagues,
+} from './views';
+
+function player(overrides: Partial<Player> & { name: string }): Player {
+  return {
+    id: overrides.name,
+    position: 'RB',
+    realTeam: 'KC',
+    score: 10,
+    gameStatus: 'pregame',
+    gameStartTime: null,
+    gameQuarter: null,
+    gameClock: null,
+    onUserTeams: 0,
+    onOpponentTeams: 0,
+    gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
+    imageUrl: '',
+    onBench: false,
+    ...overrides,
+  };
+}
+
+function team(overrides: Partial<Team> = {}): Team {
+  return {
+    id: 1,
+    name: 'My Team',
+    league: {
+      provider: 'sleeper',
+      providerLeagueId: '12345',
+      name: 'Dynasty League',
+      season: '2026',
+      totalRosters: 12,
+    },
+    totalScore: 100,
+    players: [player({ name: 'Player A' })],
+    opponent: {
+      name: 'Their Team',
+      totalScore: 90,
+      players: [player({ name: 'Player B' })],
+    },
+    ...overrides,
+  };
+}
+
+describe('leagueKeyFor', () => {
+  it('prefers the provider league id', () => {
+    expect(leagueKeyFor(team(), 0)).toBe('sleeper:12345');
+  });
+
+  it('falls back to the index when the league has no id', () => {
+    const withoutLeague = team({ league: undefined });
+    expect(leagueKeyFor(withoutLeague, 2)).toBe('league-3');
+  });
+
+  it('stays unique when providers reuse an unset team id', () => {
+    // Sleeper leagues resolved live carry no database id, so every team
+    // arrives with the same `id` — keys must not collide.
+    const teams = [
+      team({ id: undefined as unknown as number, league: { provider: 'sleeper', providerLeagueId: 'a', name: 'A' } }),
+      team({ id: undefined as unknown as number, league: { provider: 'sleeper', providerLeagueId: 'b', name: 'B' } }),
+    ];
+
+    const keys = teams.map((entry, index) => leagueKeyFor(entry, index));
+    expect(new Set(keys).size).toBe(2);
+  });
+});
+
+describe('summarizeLeagues', () => {
+  it('reports the margin and starters yet to play', () => {
+    const teams = [
+      team({
+        totalScore: 110.55,
+        players: [
+          player({ name: 'Starter', gameStatus: 'pregame' }),
+          player({ name: 'Played', gameStatus: 'final' }),
+          player({ name: 'Benched', gameStatus: 'pregame', onBench: true }),
+        ],
+        opponent: {
+          name: 'Their Team',
+          totalScore: 100,
+          players: [player({ name: 'Opp', gameStatus: 'final' })],
+        },
+      }),
+    ];
+
+    const [summary] = summarizeLeagues(teams);
+
+    expect(summary.leagueName).toBe('Dynasty League');
+    expect(summary.margin).toBeCloseTo(10.6, 5);
+    // The benched pregame player must not count.
+    expect(summary.startersYetToPlay).toBe(1);
+    expect(summary.opponentStartersYetToPlay).toBe(0);
+  });
+
+  it('falls back to the team name when no league metadata exists', () => {
+    const [summary] = summarizeLeagues([team({ league: undefined })]);
+
+    expect(summary.leagueName).toBe('My Team');
+    expect(summary.provider).toBe('unknown');
+  });
+});
+
+describe('findTeamByLeagueKey', () => {
+  const teams = [team()];
+
+  it('matches the exact key', () => {
+    expect(findTeamByLeagueKey(teams, 'sleeper:12345')?.team.name).toBe('My Team');
+  });
+
+  it('matches case-insensitively', () => {
+    expect(findTeamByLeagueKey(teams, 'SLEEPER:12345')).not.toBeNull();
+  });
+
+  it('falls back to the league name', () => {
+    expect(findTeamByLeagueKey(teams, 'Dynasty League')?.leagueKey).toBe('sleeper:12345');
+  });
+
+  it('returns null for an unknown key', () => {
+    expect(findTeamByLeagueKey(teams, 'nope')).toBeNull();
+  });
+});
+
+describe('describeMatchup', () => {
+  it('splits starters from bench on both sides', () => {
+    const source = team({
+      players: [
+        player({ name: 'Starter' }),
+        player({ name: 'Bench', onBench: true }),
+      ],
+      opponent: {
+        name: 'Their Team',
+        totalScore: 90,
+        players: [player({ name: 'Opp Bench', onBench: true })],
+      },
+    });
+
+    const matchup = describeMatchup(source, 'sleeper:12345');
+
+    expect(matchup.you.starters.map((p) => p.name)).toEqual(['Starter']);
+    expect(matchup.you.bench.map((p) => p.name)).toEqual(['Bench']);
+    expect(matchup.opponent.starters).toHaveLength(0);
+    expect(matchup.opponent.bench).toHaveLength(1);
+  });
+
+  it('labels live game state', () => {
+    const source = team({
+      players: [
+        player({
+          name: 'Live',
+          gameStatus: 'in_progress',
+          gameQuarter: 'Q3',
+          gameClock: '04:21',
+        }),
+      ],
+    });
+
+    const [live] = describeMatchup(source, 'k').you.starters;
+
+    expect(live.gameStatusLabel).toBe('Q3 04:21');
+    expect(live.percentOfGameRemaining).toBeGreaterThan(0);
+  });
+});
+
+describe('aggregatePlayerExposure', () => {
+  const shared = { name: 'Shared Guy', realTeam: 'SF' };
+
+  const teams = [
+    team({
+      league: { provider: 'sleeper', providerLeagueId: 'a', name: 'League A' },
+      players: [player({ ...shared })],
+      opponent: { name: 'Opp A', totalScore: 0, players: [] },
+    }),
+    team({
+      league: { provider: 'yahoo', providerLeagueId: 'b', name: 'League B' },
+      players: [player({ ...shared, onBench: true })],
+      opponent: {
+        name: 'Opp B',
+        totalScore: 0,
+        players: [player({ name: 'Enemy', realTeam: 'DAL' })],
+      },
+    }),
+    team({
+      league: { provider: 'yahoo', providerLeagueId: 'c', name: 'League C' },
+      players: [],
+      opponent: { name: 'Opp C', totalScore: 0, players: [player({ ...shared })] },
+    }),
+  ];
+
+  it('deduplicates a player across leagues and records each side', () => {
+    const exposures = aggregatePlayerExposure(teams);
+    const sharedPlayer = exposures.find((entry) => entry.name === 'Shared Guy');
+
+    expect(sharedPlayer?.onYourTeams).toBe(2);
+    expect(sharedPlayer?.onOpponentTeams).toBe(1);
+    expect(sharedPlayer?.conflicted).toBe(true);
+    expect(sharedPlayer?.rosteredIn).toEqual([
+      { leagueKey: 'sleeper:a', leagueName: 'League A', starting: true },
+      { leagueKey: 'yahoo:b', leagueName: 'League B', starting: false },
+    ]);
+  });
+
+  it('does not merge same-named players on different NFL teams', () => {
+    const exposures = aggregatePlayerExposure([
+      team({
+        players: [player({ name: 'Same Name', realTeam: 'KC' })],
+        opponent: {
+          name: 'Opp',
+          totalScore: 0,
+          players: [player({ name: 'Same Name', realTeam: 'BUF' })],
+        },
+      }),
+    ]);
+
+    expect(exposures.filter((entry) => entry.name === 'Same Name')).toHaveLength(2);
+  });
+
+  it('sorts by total exposure', () => {
+    expect(aggregatePlayerExposure(teams)[0].name).toBe('Shared Guy');
+  });
+});
+
+describe('searchPlayerExposure', () => {
+  const exposures = aggregatePlayerExposure([
+    team({
+      players: [player({ name: 'Patrick Mahomes', realTeam: 'KC' })],
+      opponent: {
+        name: 'Opp',
+        totalScore: 0,
+        players: [player({ name: 'Josh Allen', realTeam: 'BUF' })],
+      },
+    }),
+  ]);
+
+  it('matches on partial name, case-insensitively', () => {
+    expect(searchPlayerExposure(exposures, 'mahomes').map((e) => e.name)).toEqual([
+      'Patrick Mahomes',
+    ]);
+  });
+
+  it('matches on NFL team', () => {
+    expect(searchPlayerExposure(exposures, 'buf').map((e) => e.name)).toEqual([
+      'Josh Allen',
+    ]);
+  });
+
+  it('returns nothing for a blank query', () => {
+    expect(searchPlayerExposure(exposures, '   ')).toEqual([]);
+  });
+});
+
+describe('buildRootingGuide', () => {
+  it('separates players to root for, against, and conflicted', () => {
+    const hero = { name: 'Hero', realTeam: 'SF' };
+    const enemy = { name: 'Enemy', realTeam: 'DAL' };
+    const conflicted = { name: 'Conflicted', realTeam: 'PHI' };
+
+    const guide = buildRootingGuide([
+      team({
+        name: 'Team One',
+        players: [player({ ...hero }), player({ ...conflicted })],
+        opponent: { name: 'Opp One', totalScore: 0, players: [player({ ...enemy })] },
+      }),
+      team({
+        name: 'Team Two',
+        players: [player({ ...hero })],
+        opponent: {
+          name: 'Opp Two',
+          totalScore: 0,
+          players: [player({ ...enemy }), player({ ...conflicted })],
+        },
+      }),
+    ]);
+
+    expect(guide.rootFor.map((p) => p.name)).toEqual(['Hero']);
+    expect(guide.rootAgainst.map((p) => p.name)).toEqual(['Enemy']);
+    expect(guide.conflicted.map((p) => p.name)).toEqual(['Conflicted']);
+    expect(guide.conflicted[0].yourLeagues).toEqual(['Team One']);
+    expect(guide.conflicted[0].opponentLeagues).toEqual(['Opp Two']);
+  });
+});

--- a/apps/web/src/lib/mcp/views.ts
+++ b/apps/web/src/lib/mcp/views.ts
@@ -1,0 +1,375 @@
+/**
+ * Shapes the `Team[]` the app already builds into the payloads the MCP
+ * tools return.
+ *
+ * Everything here is a pure transform: no fetching, no Supabase, no
+ * Next.js. The route handler fetches once per request and hands the
+ * result to these functions, which keeps the tools cheap to test.
+ */
+import {
+  getGamePercentRemaining,
+  getGameStatusLabel,
+  processMatchups,
+  type Player,
+  type Team,
+} from '@roster-loom/core';
+
+/** A player as reported over MCP — the display noise (images) stripped. */
+export type McpPlayer = {
+  name: string;
+  position: string;
+  nflTeam: string;
+  points: number;
+  /** Whether the player is in the starting lineup (not on the bench). */
+  starting: boolean;
+  /** Raw game state: `pregame`, `in_progress` or `final`. */
+  gameStatus: string;
+  /** Human-readable game state, e.g. `Q3 04:21`, `Sun 1:00 PM`, `Final`. */
+  gameStatusLabel: string | null;
+  /** Rough share of the game clock left, 0-100, for live games only. */
+  percentOfGameRemaining: number | null;
+};
+
+/** One side of a head-to-head matchup. */
+export type McpSide = {
+  teamName: string;
+  points: number;
+  starters: McpPlayer[];
+  bench: McpPlayer[];
+};
+
+/** A league, the user's team in it, and the current opponent. */
+export type McpLeague = {
+  /** Stable handle other tools accept to address this league. */
+  leagueKey: string;
+  provider: string;
+  leagueName: string;
+  season: string | null;
+  totalRosters: number | null;
+  teamName: string;
+  points: number;
+  opponentName: string;
+  opponentPoints: number;
+  /** Positive when the user is ahead. */
+  margin: number;
+  /** Starters whose game has not kicked off yet. */
+  startersYetToPlay: number;
+  /** Opponent starters whose game has not kicked off yet. */
+  opponentStartersYetToPlay: number;
+};
+
+/** Where a single NFL player shows up across every league. */
+export type McpPlayerExposure = {
+  name: string;
+  position: string;
+  nflTeam: string;
+  points: number;
+  gameStatus: string;
+  gameStatusLabel: string | null;
+  /** Leagues where the user rosters the player. */
+  rosteredIn: { leagueKey: string; leagueName: string; starting: boolean }[];
+  /** Leagues where the user's opponent rosters the player. */
+  opposedIn: { leagueKey: string; leagueName: string; starting: boolean }[];
+  /** How many of the user's teams roster this player. */
+  onYourTeams: number;
+  /** How many opposing teams roster this player. */
+  onOpponentTeams: number;
+  /** True when the player helps in one league and hurts in another. */
+  conflicted: boolean;
+};
+
+/**
+ * Builds the stable handle used to address a league across tool calls.
+ *
+ * `Team.id` is not dependable — the Sleeper builder sets it from a
+ * database column that live-resolved leagues don't carry — so the
+ * provider's own league id is preferred, with the team's index as a
+ * last resort.
+ *
+ * @param team - The team to derive a key for.
+ * @param index - The team's position in the overall list.
+ * @returns A key unique within a single response.
+ */
+export function leagueKeyFor(team: Team, index: number): string {
+  if (team.league?.providerLeagueId) {
+    return `${team.league.provider}:${team.league.providerLeagueId}`;
+  }
+
+  if (team.league?.provider) {
+    return `${team.league.provider}:team-${index + 1}`;
+  }
+
+  return `league-${index + 1}`;
+}
+
+function toMcpPlayer(player: Player): McpPlayer {
+  return {
+    name: player.name,
+    position: player.position,
+    nflTeam: player.realTeam,
+    points: player.score,
+    starting: !player.onBench,
+    gameStatus: player.gameStatus,
+    gameStatusLabel: getGameStatusLabel(player),
+    percentOfGameRemaining: getGamePercentRemaining(player),
+  };
+}
+
+function countYetToPlay(players: Player[]): number {
+  return players.filter(
+    (player) => !player.onBench && player.gameStatus === 'pregame',
+  ).length;
+}
+
+function roundToTenth(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * Summarises every league the user has a team in.
+ *
+ * @param teams - The teams built for the request.
+ * @returns One entry per league, in the order the providers returned them.
+ */
+export function summarizeLeagues(teams: Team[]): McpLeague[] {
+  return teams.map((team, index) => {
+    const points = roundToTenth(team.totalScore);
+    const opponentPoints = roundToTenth(team.opponent.totalScore);
+
+    return {
+      leagueKey: leagueKeyFor(team, index),
+      provider: team.league?.provider ?? 'unknown',
+      leagueName: team.league?.name ?? team.name,
+      season: team.league?.season ?? null,
+      totalRosters: team.league?.totalRosters ?? null,
+      teamName: team.name,
+      points,
+      opponentName: team.opponent.name,
+      opponentPoints,
+      // Derived from the rounded values so that the three numbers always
+      // reconcile in the tool output.
+      margin: roundToTenth(points - opponentPoints),
+      startersYetToPlay: countYetToPlay(team.players),
+      opponentStartersYetToPlay: countYetToPlay(team.opponent.players),
+    };
+  });
+}
+
+/**
+ * Finds a team by its league key.
+ *
+ * @param teams - The teams built for the request.
+ * @param leagueKey - The key returned by a previous tool call.
+ * @returns The matching team and its key, or `null` when absent.
+ */
+export function findTeamByLeagueKey(
+  teams: Team[],
+  leagueKey: string,
+): { team: Team; leagueKey: string } | null {
+  const normalized = leagueKey.trim().toLowerCase();
+
+  for (let index = 0; index < teams.length; index += 1) {
+    const key = leagueKeyFor(teams[index], index);
+    if (key.toLowerCase() === normalized) {
+      return { team: teams[index], leagueKey: key };
+    }
+  }
+
+  // Fall back to matching on the league or team name, since a model
+  // relaying a name from an earlier response is a likely mistake.
+  for (let index = 0; index < teams.length; index += 1) {
+    const team = teams[index];
+    const candidates = [team.league?.name, team.name, team.league?.providerLeagueId];
+    if (
+      candidates.some(
+        (candidate) => candidate && candidate.trim().toLowerCase() === normalized,
+      )
+    ) {
+      return { team, leagueKey: leagueKeyFor(team, index) };
+    }
+  }
+
+  return null;
+}
+
+function toSide(name: string, points: number, players: Player[]): McpSide {
+  const mapped = players.map(toMcpPlayer);
+
+  return {
+    teamName: name,
+    points: roundToTenth(points),
+    starters: mapped.filter((player) => player.starting),
+    bench: mapped.filter((player) => !player.starting),
+  };
+}
+
+/** A full head-to-head matchup for one league. */
+export type McpMatchup = McpLeague & {
+  you: McpSide;
+  opponent: McpSide;
+};
+
+/**
+ * Expands a single league into both full rosters with per-player scoring.
+ *
+ * @param team - The team to describe.
+ * @param leagueKey - The team's stable league key.
+ * @returns The matchup, including bench players on both sides.
+ */
+export function describeMatchup(team: Team, leagueKey: string): McpMatchup {
+  const [summary] = summarizeLeagues([team]);
+
+  return {
+    ...summary,
+    leagueKey,
+    you: toSide(team.name, team.totalScore, team.players),
+    opponent: toSide(
+      team.opponent.name,
+      team.opponent.totalScore,
+      team.opponent.players,
+    ),
+  };
+}
+
+/**
+ * Aggregates every rostered player across all leagues, recording which
+ * leagues they help in and which they hurt in.
+ *
+ * Players are matched on name plus NFL team, the same rule the app's
+ * cross-team badges use.
+ *
+ * @param teams - The teams built for the request.
+ * @returns One entry per distinct player, most-exposed first.
+ */
+export function aggregatePlayerExposure(teams: Team[]): McpPlayerExposure[] {
+  const byPlayer = new Map<string, McpPlayerExposure>();
+
+  const keyOf = (player: Player) =>
+    `${player.name.trim().toLowerCase()}|${player.realTeam.trim().toLowerCase()}`;
+
+  const record = (
+    player: Player,
+    leagueKey: string,
+    leagueName: string,
+    isOpponent: boolean,
+  ) => {
+    const key = keyOf(player);
+    const existing = byPlayer.get(key);
+
+    const entry: McpPlayerExposure = existing ?? {
+      name: player.name,
+      position: player.position,
+      nflTeam: player.realTeam,
+      points: player.score,
+      gameStatus: player.gameStatus,
+      gameStatusLabel: getGameStatusLabel(player),
+      rosteredIn: [],
+      opposedIn: [],
+      onYourTeams: 0,
+      onOpponentTeams: 0,
+      conflicted: false,
+    };
+
+    const target = isOpponent ? entry.opposedIn : entry.rosteredIn;
+    target.push({ leagueKey, leagueName, starting: !player.onBench });
+
+    entry.onYourTeams = entry.rosteredIn.length;
+    entry.onOpponentTeams = entry.opposedIn.length;
+    entry.conflicted = entry.rosteredIn.length > 0 && entry.opposedIn.length > 0;
+
+    byPlayer.set(key, entry);
+  };
+
+  teams.forEach((team, index) => {
+    const leagueKey = leagueKeyFor(team, index);
+    const leagueName = team.league?.name ?? team.name;
+
+    team.players.forEach((player) => record(player, leagueKey, leagueName, false));
+    team.opponent.players.forEach((player) =>
+      record(player, leagueKey, leagueName, true),
+    );
+  });
+
+  return Array.from(byPlayer.values()).sort((a, b) => {
+    const exposureDelta =
+      b.onYourTeams + b.onOpponentTeams - (a.onYourTeams + a.onOpponentTeams);
+    return exposureDelta !== 0 ? exposureDelta : b.points - a.points;
+  });
+}
+
+/**
+ * Filters aggregated exposure down to players matching a search string.
+ *
+ * @param exposures - The aggregated players to search.
+ * @param query - A case-insensitive substring of the player's name or
+ *   NFL team.
+ * @returns The matching players, in the order given.
+ */
+export function searchPlayerExposure(
+  exposures: McpPlayerExposure[],
+  query: string,
+): McpPlayerExposure[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return [];
+  }
+
+  return exposures.filter(
+    (exposure) =>
+      exposure.name.toLowerCase().includes(normalized) ||
+      exposure.nflTeam.toLowerCase().includes(normalized),
+  );
+}
+
+/** The cross-league rooting guide. */
+export type McpRootingGuide = {
+  /** Players on more than one of your teams and no opponent's. */
+  rootFor: { name: string; position: string; nflTeam: string; points: number; leagues: string[] }[];
+  /** Players on more than one opponent team and none of yours. */
+  rootAgainst: { name: string; position: string; nflTeam: string; points: number; leagues: string[] }[];
+  /** Players on both sides of your slate. */
+  conflicted: {
+    name: string;
+    position: string;
+    nflTeam: string;
+    points: number;
+    yourLeagues: string[];
+    opponentLeagues: string[];
+  }[];
+};
+
+/**
+ * Classifies players into who you want to do well, who you don't, and
+ * who you are conflicted about. Wraps the app's existing matchup report.
+ *
+ * @param teams - The teams built for the request.
+ * @returns The three buckets.
+ */
+export function buildRootingGuide(teams: Team[]): McpRootingGuide {
+  const { fantasyHeroes, publicEnemies, doubleAgents } = processMatchups(teams);
+
+  return {
+    rootFor: fantasyHeroes.map((player) => ({
+      name: player.name,
+      position: player.position,
+      nflTeam: player.realTeam,
+      points: player.score,
+      leagues: player.matchups,
+    })),
+    rootAgainst: publicEnemies.map((player) => ({
+      name: player.name,
+      position: player.position,
+      nflTeam: player.realTeam,
+      points: player.score,
+      leagues: player.matchups,
+    })),
+    conflicted: doubleAgents.map((player) => ({
+      name: player.name,
+      position: player.position,
+      nflTeam: player.realTeam,
+      points: player.score,
+      yourLeagues: player.userMatchups,
+      opponentLeagues: player.opponentMatchups,
+    })),
+  };
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,10 @@ Every provider follows the same shape: an `actions.ts` (server), a `page.tsx`
 (integration management UI), a per-provider `README.md`, and an
 `*.example.json` snapshot for the most useful API response.
 
+`getTeams()` is the single seam every consumer sits behind: the web
+render, the mobile app (via `/api/teams/refresh`), demo mode, and the
+[MCP server](MCP.md) (via `/api/mcp`) all read the same `Team[]`.
+
 ## Provider integration pattern
 
 Each integration under `apps/web/src/app/integrations/<provider>/`:
@@ -95,6 +99,8 @@ repo's tables on the shared OttoneuDB project):
 - `fp_leagues` — league rows imported from each provider
 - `fp_teams` — teams pulled from each league
 - `fp_notes` — free-form user notes
+- `fp_mcp_tokens` — hashed personal access tokens for the [MCP
+  server](MCP.md); the only table here with RLS enabled
 
 Server-side Supabase access goes through `apps/web/src/utils/supabase/server.ts`;
 client-side through `apps/web/src/utils/supabase/client.ts`. `middleware.ts`

--- a/docs/CODE_ORGANIZATION.md
+++ b/docs/CODE_ORGANIZATION.md
@@ -49,9 +49,10 @@ Currently shared: shared types (`types.ts`), Sleeper helpers
 | `globals.css`                 | Tailwind base layer + CSS variables                    |
 | `actions.ts`                  | Cross-provider server actions (team building, scoring) |
 | `actions.test.ts`             | Jest tests for `actions.ts`                            |
-| `(dashboard)/`                | Authenticated route group (matchup report, etc.)      |
+| `(dashboard)/`                | Authenticated route group (matchup report, MCP tokens) |
 | `api/auth/<provider>/route.ts`| OAuth callbacks                                        |
 | `api/teams/`                  | Team-related route handlers                            |
+| `api/mcp/route.ts`            | Hosted MCP server endpoint (see [MCP.md](MCP.md))      |
 | `integrations/<provider>/`    | One folder per fantasy provider (see below)            |
 | `login/`, `register/`         | Auth pages                                             |
 
@@ -87,6 +88,10 @@ Component tests are colocated as `<name>.test.tsx` next to the implementation.
 - `doc-map.test.ts`     enforces that AGENTS.md / CLAUDE.md links resolve
 - `fetch-json.test.ts`  tests for `fetchJson` (the implementation lives
                         in `packages/core/`)
+- `mcp/`                the MCP server: `protocol.ts` (JSON-RPC / transport),
+                        `tools.ts` (definitions + handlers), `views.ts`
+                        (pure `Team[]` transforms), `tokens.ts` (access
+                        tokens). See [MCP.md](MCP.md).
 
 Shared logic — `types.ts`, `sleeper.ts`, `fetch-json.ts`, `mock-data.ts` —
 now lives in `packages/core/src/` and is imported as `@roster-loom/core`.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,148 @@
+# MCP Server
+
+Roster Loom hosts a [Model Context Protocol](https://modelcontextprotocol.io)
+server so an AI assistant can read your leagues, rosters and live
+matchups across every connected provider.
+
+It runs inside the Next.js app — there is no separate service to deploy.
+The endpoint ships with the Vercel deployment at:
+
+```
+POST https://<your-deployment>/api/mcp
+```
+
+## Setup
+
+The server needs the `fp_mcp_tokens` table and its lookup function, so
+apply the migrations to the linked project once before first use:
+
+```bash
+npx supabase db push
+```
+
+Until that runs, `/mcp` cannot mint tokens and every request to
+`/api/mcp` answers `401`.
+
+No new environment variables are required. `SUPABASE_SERVICE_ROLE_KEY`
+is used when present — MCP callers authenticate with their own token and
+so carry no Supabase session — and the endpoint falls back to the anon
+key, matching how the existing bearer-authenticated
+`/api/teams/refresh` path queries. Either way every query is explicitly
+scoped by user id.
+
+## Connecting a client
+
+1. Sign in and open **/mcp**.
+2. Create an access token and copy it — it is shown once.
+3. Point your client at the endpoint with the token as a bearer header.
+
+Claude Code:
+
+```bash
+claude mcp add --transport http roster-loom https://<your-deployment>/api/mcp \
+  --header "Authorization: Bearer rl_mcp_..."
+```
+
+`claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "roster-loom": {
+      "type": "http",
+      "url": "https://<your-deployment>/api/mcp",
+      "headers": { "Authorization": "Bearer rl_mcp_..." }
+    }
+  }
+}
+```
+
+Locally, the dev server on port 9002 serves the same endpoint at
+`http://localhost:9002/api/mcp`.
+
+## Tools
+
+| Tool | Arguments | Returns |
+| ---- | --------- | ------- |
+| `list_leagues` | — | Every league, with your score, the opponent's, the margin, and starters yet to play. Returns the `leagueKey` other tools take. |
+| `get_league_matchup` | `leagueKey` | One league's full matchup: both starting lineups and benches, per-player points, live game state. |
+| `list_rostered_players` | `position?`, `onlyStarters?`, `onlyMultiLeague?` | Every player across all leagues, deduplicated, with the leagues they're rostered and opposed in. |
+| `find_player` | `query` | Where a player appears across every roster, yours and your opponents'. |
+| `get_rooting_guide` | — | Players to root for, root against, and be conflicted about. |
+
+All tools are read-only. Nothing writes back to a fantasy provider.
+
+`leagueKey` is `<provider>:<providerLeagueId>` (e.g. `sleeper:123456789`).
+Tools also accept a league or team name, since a model relaying a name
+from an earlier answer is a likely mistake.
+
+## Authentication
+
+MCP clients store a static string in their config, so Supabase's
+hour-long access tokens are unusable here. Instead `/mcp` mints
+long-lived personal access tokens:
+
+- The token is `rl_mcp_` + 32 random bytes.
+- Only its SHA-256 is stored, in `fp_mcp_tokens`. The plaintext is shown
+  once and is unrecoverable.
+- Requests present it as `Authorization: Bearer <token>`.
+- Verification goes through the `fp_mcp_token_owner` SECURITY DEFINER
+  function, which resolves the hash to a user id and stamps
+  `last_used_at`.
+- Revoking sets `revoked_at`, which takes effect on the next request.
+
+`fp_mcp_tokens` is the one table in this schema with RLS enabled — a user
+can only ever see and manage their own tokens. Unlike the other `fp_`
+tables it holds credential material, so it does not inherit their
+open-by-default posture.
+
+A token grants read access to everything the owning account can see.
+Treat it like a password, and revoke it at `/mcp` if it leaks.
+
+## Transport
+
+The server speaks MCP's Streamable HTTP transport statelessly: one POST
+carries a JSON-RPC message, one response carries the answer. There is no
+SSE stream and no session id, because the server never initiates
+messages and retains nothing between requests — which is what lets it
+run on serverless hosting.
+
+- `POST` — JSON-RPC. Supports `initialize`, `ping`, `tools/list`,
+  `tools/call`, notifications, and pre-2025-06-18 batch arrays.
+- `GET` — `405`. No server-initiated event stream is offered.
+- `DELETE` — `204`. There is no session to terminate.
+
+Protocol revisions `2025-06-18`, `2025-03-26` and `2024-11-05` are
+accepted; the client's choice is echoed when supported.
+
+The implementation is hand-rolled in `apps/web/src/lib/mcp/` rather than
+delegated to an adapter. The tools-only, stateless surface is small, and
+the available Next.js adapter pins an exact `@modelcontextprotocol/sdk`
+version and hard-depends on `redis`, neither of which this app needs.
+
+## Layout
+
+```
+apps/web/src/lib/mcp/
+├── protocol.ts     # JSON-RPC dispatch + Streamable HTTP semantics
+├── tools.ts        # Tool definitions and handlers
+├── views.ts        # Pure Team[] -> tool payload transforms
+└── tokens.ts       # Token minting, hashing, verification
+
+apps/web/src/app/api/mcp/route.ts        # HTTP layer: auth, data loading
+apps/web/src/app/(dashboard)/mcp/        # Token management UI
+supabase/migrations/*_add_fp_mcp_tokens.sql
+```
+
+Tools are pure functions of the `Team[]` that `getTeams()` already
+builds, so the MCP server inherits every provider, live scoring, and
+[demo mode](DEMO_MODE.md) for free — send `x-demo-mode: 1` to exercise
+the tools with fake data out of season.
+
+## Performance
+
+The provider fan-out is expensive (1–3 external APIs), so it is loaded
+lazily and at most once per request: `initialize` and `tools/list` never
+touch a provider, and a batch containing several `tools/call` messages
+still fans out only once. `dispatchMcpPayload` owns that guarantee, so
+it holds regardless of how the route's loader is written.

--- a/docs/references/database-schema.md
+++ b/docs/references/database-schema.md
@@ -45,7 +45,29 @@ CREATE TABLE public.fp_user_integrations (
   provider_user_id text,
   CONSTRAINT user_integrations_pkey PRIMARY KEY (id)
 );
+
+CREATE TABLE public.fp_mcp_tokens (
+  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+  user_id uuid NOT NULL DEFAULT auth.uid(),
+  name text NOT NULL DEFAULT 'MCP token',
+  token_prefix text NOT NULL,
+  token_hash text NOT NULL UNIQUE,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  last_used_at timestamp with time zone,
+  revoked_at timestamp with time zone,
+  CONSTRAINT fp_mcp_tokens_pkey PRIMARY KEY (id),
+  CONSTRAINT fp_mcp_tokens_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES auth.users(id) ON DELETE CASCADE
+);
 ```
+
+`fp_mcp_tokens` is the only table here with **row level security
+enabled** — it stores credential material for the [MCP
+server](../MCP.md), so a user may only read and manage their own rows.
+Token verification does not read the table directly; it goes through the
+`fp_mcp_token_owner(text)` SECURITY DEFINER function, which resolves a
+SHA-256 hash to a user id and stamps `last_used_at`.
 
 A `fp_teams` table also exists (originally created as `teams` by
 `supabase/migrations/20250907113000_add_teams_table.sql` and constrained

--- a/packages/core/src/demo-data.ts
+++ b/packages/core/src/demo-data.ts
@@ -488,6 +488,13 @@ export function generateDemoTeams(
     teams.push({
       id: t + 1,
       name: TEAM_NAMES[t % TEAM_NAMES.length],
+      league: {
+        provider: 'demo',
+        providerLeagueId: `demo-league-${t + 1}`,
+        name: `${TEAM_NAMES[t % TEAM_NAMES.length]} League`,
+        season: String(new Date(nowMs).getFullYear()),
+        totalRosters: 12,
+      },
       totalScore: sumStarters(userPlayers),
       players: userPlayers,
       opponent: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -84,6 +84,27 @@ export type GroupedPlayer = Player & {
   matchupColors: PlayerMatchupColor[];
 };
 
+/** The fantasy platforms a league can come from. */
+export type FantasyProvider = 'sleeper' | 'yahoo' | 'ottoneu' | 'demo';
+
+/**
+ * Identifies the league a team plays in. Attached to {@link Team} so
+ * consumers that aggregate across providers (the MCP server, reports)
+ * can tell two teams apart by more than a display name.
+ */
+export type LeagueRef = {
+  /** The platform hosting the league. */
+  provider: FantasyProvider;
+  /** The league's identifier in the provider's own namespace. */
+  providerLeagueId: string;
+  /** The league's display name. */
+  name: string;
+  /** The season the league is being played in, when known. */
+  season?: string | null;
+  /** How many teams the league has, when known. */
+  totalRosters?: number | null;
+};
+
 /**
  * Represents a fantasy football team.
  */
@@ -92,6 +113,8 @@ export type Team = {
   id: number;
   /** The name of the team. */
   name: string;
+  /** The league this team plays in, when the provider supplied it. */
+  league?: LeagueRef;
   /** The total score of the team. */
   totalScore: number;
   /** The list of players on the team. */

--- a/supabase/migrations/20260728120000_add_fp_mcp_tokens.sql
+++ b/supabase/migrations/20260728120000_add_fp_mcp_tokens.sql
@@ -1,0 +1,75 @@
+-- Personal access tokens for the hosted MCP server (`POST /api/mcp`).
+--
+-- MCP clients (Claude Desktop, Claude Code, ...) hold a static string in
+-- their config, so Supabase's hour-long access tokens are unusable here.
+-- Instead a user mints a long-lived `rl_mcp_<random>` token from /mcp and
+-- sends it as `Authorization: Bearer <token>`.
+--
+-- Only the SHA-256 of the token is stored; the plaintext is shown once at
+-- creation and is unrecoverable afterwards.
+CREATE TABLE public.fp_mcp_tokens (
+  id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  user_id UUID NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id) ON DELETE CASCADE,
+  -- User-facing label so a token can be identified before revoking it.
+  name TEXT NOT NULL DEFAULT 'MCP token',
+  -- First few characters of the plaintext, kept for display only.
+  token_prefix TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_used_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX fp_mcp_tokens_user_id_idx ON public.fp_mcp_tokens (user_id);
+
+-- Unlike the other fp_ tables (which predate any RLS policy), this one
+-- holds credential material, so it is locked down: a user may only ever
+-- see and manage their own tokens, and the hash column is never readable
+-- by the anon role. Token verification goes through
+-- fp_mcp_token_owner() below, which runs as the definer.
+ALTER TABLE public.fp_mcp_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY fp_mcp_tokens_select_own ON public.fp_mcp_tokens
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY fp_mcp_tokens_insert_own ON public.fp_mcp_tokens
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY fp_mcp_tokens_update_own ON public.fp_mcp_tokens
+  FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY fp_mcp_tokens_delete_own ON public.fp_mcp_tokens
+  FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+-- Resolves a presented token hash to its owner and stamps last_used_at.
+--
+-- SECURITY DEFINER because the caller is unauthenticated by definition —
+-- the token *is* the credential being checked. Safe to expose: the caller
+-- must already know the SHA-256 of a 32-byte random token, and the
+-- function returns nothing but the owning user id.
+CREATE OR REPLACE FUNCTION public.fp_mcp_token_owner(p_token_hash TEXT)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id UUID;
+BEGIN
+  UPDATE public.fp_mcp_tokens
+     SET last_used_at = NOW()
+   WHERE token_hash = p_token_hash
+     AND revoked_at IS NULL
+  RETURNING user_id INTO v_user_id;
+
+  RETURN v_user_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_token_owner(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_token_owner(TEXT) TO anon, authenticated;


### PR DESCRIPTION
## Summary

Adds a hosted Model Context Protocol (MCP) server that allows AI assistants (Claude, etc.) to read fantasy football leagues, rosters, and live matchups across all connected providers. The server runs inside the Next.js app as a stateless JSON-RPC endpoint at `POST /api/mcp`, authenticated via personal access tokens minted at `/mcp`.

## Key Changes

- **MCP Protocol Implementation** (`lib/mcp/protocol.ts`, `lib/mcp/protocol.test.ts`)
  - Minimal, stateless implementation of MCP&#39;s Streamable HTTP transport
  - Supports protocol versions 2024-11-05, 2025-03-26, 2025-06-18
  - Handles `initialize`, `tools/list`, and `tools/call` JSON-RPC methods
  - No session state; each POST is fully self-contained

- **MCP Tools** (`lib/mcp/tools.ts`, `lib/mcp/tools.test.ts`)
  - Five tools: `list_leagues`, `get_league_matchup`, `list_rostered_players`, `find_player`, `get_rooting_guide`
  - Pure functions of already-fetched `Team[]` data plus arguments
  - Single provider fan-out per request regardless of which tool is called
  - Comprehensive test coverage over demo data

- **Data Transformation Layer** (`lib/mcp/views.ts`, `lib/mcp/views.test.ts`)
  - Shapes `Team[]` into MCP payloads (removes display noise like images)
  - Stable league keys for cross-tool addressing
  - Player exposure aggregation across leagues
  - Rooting guide generation (players to root for/against/conflicted about)

- **Token Management**
  - `lib/mcp/tokens.ts`: Mint and verify personal access tokens with SHA-256 hashing
  - `app/(dashboard)/mcp/page.tsx`: UI for creating and revoking tokens
  - `app/(dashboard)/mcp/actions.ts`: Server actions for token lifecycle
  - `app/(dashboard)/mcp/components.tsx`: Token manager component with copy-to-clipboard

- **API Route** (`app/api/mcp/route.ts`)
  - Handles POST requests with JSON-RPC payloads
  - Authenticates via bearer token
  - Lazily loads user&#39;s teams only for `tools/call` (not for handshake)
  - Respects demo mode and returns appropriate protocol version headers

- **Database** (`supabase/migrations/20260728120000_add_fp_mcp_tokens.sql`)
  - `fp_mcp_tokens` table for storing token hashes and metadata
  - `fp_mcp_token_owner` SECURITY DEFINER function for verification
  - Row-level security to prevent users from accessing other users&#39; tokens

- **Type System Updates** (`packages/core/src/types.ts`)
  - Added `FantasyProvider` type and an optional `LeagueRef` (`Team.league`)
  - Enables MCP tools to label teams with league name, season, total rosters

- **Provider Integration Updates**
  - Sleeper: Attaches league metadata to teams
  - Yahoo: Loads league lookup table to label teams with league names
  - Demo: Generates league metadata for demo teams

- **Documentation** (`docs/MCP.md`)
  - Setup instructions (database migrations required)
  - Client connection examples (Claude Code, Claude Desktop)
  - Tool reference table

- **Navigation** (`components/app-navigation.tsx`)
  - Added `/mcp` link to main navigation

## Implementation Details

- **Stateless design:** No session management; every request is independent. Ideal for serverless hosting.
- **Lazy loading:** Teams are only fetched when a tool is actually called, not during protocol handshakes.
- **Token security:** Plaintext tokens shown once at creation; only SHA-256 hashes stored. Verification hashes the presented token and resolves it through the `fp_mcp_token_owner` SECURITY DEFINER function, which checks `revoked_at` and stamps `last_used_at`.
- **Error handling:** Tool-level errors reported via `isError` flag so models can see and recover from them.
- **Dual output:** Tools return both JSON text (for model transcripts) and `structuredContent` (for clients consuming tool output programmatically).

## Before merging

`fp_mcp_tokens` and its lookup function must exist before the server works — apply the migration to the linked project with `npx supabase db push`. Until then `/mcp` cannot mint tokens and every request to `/api/mcp` answers `401`.

The authenticated happy path has not been exercised against a real Supabase project. Verified: 199 Jest tests (every tool over generated data and over the JSON-RPC dispatcher), a production build, and live requests confirming `401` without a token, `401` with an invalid one, `405` on GET, `204` on DELETE. Worth one real tool call from a client before relying on it.

https://claude.ai/code/session_01Hqctre9xYMV37SaNah7gQd