### PR TITLE
Add OAuth Dynamic Client Registration to the MCP server

### DIFF
--- a/apps/web/src/app/(dashboard)/mcp/page.tsx
+++ b/apps/web/src/app/(dashboard)/mcp/page.tsx
@@ -1,9 +1,9 @@
-import { headers } from 'next/headers';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { AppNavigation } from '@/components/app-navigation';
 import { MCP_TOOLS } from '@/lib/mcp/tools';
+import { resolveOrigin } from '@/lib/mcp/server-url';
 import { createClient } from '@/utils/supabase/server';
 
 import { listMcpTokens } from './actions';
@@ -17,19 +17,8 @@ export const dynamic = 'force-dynamic';
  * preview and production alike.
  */
 async function resolveServerUrl(): Promise<string> {
-  const headerList = await headers();
-  const host = headerList.get('host');
-
-  if (!host) {
-    return '/api/mcp';
-  }
-
-  const forwardedProto = headerList.get('x-forwarded-proto');
-  const protocol =
-    forwardedProto?.split(',')[0]?.trim() ||
-    (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https');
-
-  return `${protocol}://${host}/api/mcp`;
+  const origin = await resolveOrigin();
+  return origin ? `${origin}/api/mcp` : '/api/mcp';
 }
 
 /**

--- a/apps/web/src/app/.well-known/oauth-authorization-server/[[...path]]/route.ts
+++ b/apps/web/src/app/.well-known/oauth-authorization-server/[[...path]]/route.ts
@@ -1,0 +1,27 @@
+/**
+ * OAuth Authorization Server Metadata (RFC 8414), so a Dynamic Client
+ * Registration-capable MCP client can discover the authorize, token and
+ * registration endpoints without hardcoding them. The catch-all segment
+ * accepts both the bare well-known path and any resource-path-appended
+ * form a client may probe.
+ */
+import { NextResponse } from 'next/server';
+
+import { resolveOrigin } from '@/lib/mcp/server-url';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const origin = await resolveOrigin();
+
+  return NextResponse.json({
+    issuer: origin,
+    authorization_endpoint: `${origin}/mcp/authorize`,
+    token_endpoint: `${origin}/api/mcp/token`,
+    registration_endpoint: `${origin}/api/mcp/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none'],
+  });
+}

--- a/apps/web/src/app/.well-known/oauth-protected-resource/[[...path]]/route.ts
+++ b/apps/web/src/app/.well-known/oauth-protected-resource/[[...path]]/route.ts
@@ -1,0 +1,25 @@
+/**
+ * OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint.
+ *
+ * A 401 from /api/mcp points here (via the `resource_metadata` param on
+ * `WWW-Authenticate`) so a client can discover which authorization
+ * server to use instead of requiring a hand-pasted token. The catch-all
+ * segment accepts both the bare well-known path and the
+ * resource-path-appended form (`/.well-known/oauth-protected-resource/api/mcp`)
+ * that RFC 9728 and the MCP auth spec both allow.
+ */
+import { NextResponse } from 'next/server';
+
+import { resolveOrigin } from '@/lib/mcp/server-url';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const origin = await resolveOrigin();
+
+  return NextResponse.json({
+    resource: `${origin}/api/mcp`,
+    authorization_servers: [origin],
+    bearer_methods_supported: ['header'],
+  });
+}

--- a/apps/web/src/app/api/mcp/register/route.ts
+++ b/apps/web/src/app/api/mcp/register/route.ts
@@ -1,0 +1,70 @@
+/**
+ * OAuth Dynamic Client Registration (RFC 7591).
+ *
+ * Open registration, no admin approval: a connector UI calls this the
+ * first time a user adds the server, before any human is in the loop.
+ * Every registered client is public (no client_secret) — PKCE is
+ * mandatory on /mcp/authorize instead. See docs/MCP.md.
+ */
+import { NextResponse } from 'next/server';
+
+import { registerOAuthClient } from '@/lib/mcp/oauth';
+import { createMcpSupabaseClient } from '@/lib/mcp/supabase';
+
+export const dynamic = 'force-dynamic';
+
+function errorResponse(error: string, description: string, status = 400) {
+  return NextResponse.json({ error, error_description: description }, { status });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('invalid_client_metadata', 'Request body is not valid JSON.');
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return errorResponse('invalid_client_metadata', 'Request body must be a JSON object.');
+  }
+
+  const metadata = body as Record<string, unknown>;
+  const redirectUris = metadata.redirect_uris;
+
+  if (
+    !Array.isArray(redirectUris) ||
+    redirectUris.length === 0 ||
+    !redirectUris.every((uri) => typeof uri === 'string' && uri.length > 0)
+  ) {
+    return errorResponse('invalid_client_metadata', 'redirect_uris must be a non-empty array of strings.');
+  }
+
+  for (const uri of redirectUris) {
+    try {
+      new URL(uri as string);
+    } catch {
+      return errorResponse('invalid_redirect_uri', `Not a valid absolute URL: ${uri}`);
+    }
+  }
+
+  const clientName =
+    typeof metadata.client_name === 'string' && metadata.client_name.trim()
+      ? metadata.client_name.trim().slice(0, 200)
+      : 'Unnamed MCP client';
+
+  const supabase = createMcpSupabaseClient();
+  const client = await registerOAuthClient(supabase, clientName, redirectUris as string[]);
+
+  return NextResponse.json(
+    {
+      client_id: client.clientId,
+      client_name: client.clientName,
+      redirect_uris: client.redirectUris,
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    },
+    { status: 201 },
+  );
+}

--- a/apps/web/src/app/api/mcp/route.ts
+++ b/apps/web/src/app/api/mcp/route.ts
@@ -7,47 +7,38 @@
  * and holds nothing between requests — which is what lets it run on
  * serverless hosting alongside the rest of the app.
  *
- * Auth is a personal access token minted at /mcp and presented as
- * `Authorization: Bearer rl_mcp_...`; see docs/MCP.md.
+ * Auth is either a personal access token minted at /mcp, or an OAuth
+ * access token obtained through the Dynamic Client Registration flow at
+ * /mcp/authorize — both presented as `Authorization: Bearer ...`; see
+ * docs/MCP.md.
  */
 import { NextResponse } from 'next/server';
-import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 
 import { getCurrentNflWeek, getTeams } from '@/app/actions';
 import { DEMO_HEADER, resolveDemoMode } from '@/lib/demo-mode';
 import { dispatchMcpPayload, SUPPORTED_PROTOCOL_VERSIONS } from '@/lib/mcp/protocol';
+import { resolveOAuthAccessTokenUser } from '@/lib/mcp/oauth';
+import { resolveOrigin } from '@/lib/mcp/server-url';
+import { createMcpSupabaseClient } from '@/lib/mcp/supabase';
 import type { McpToolContext } from '@/lib/mcp/tools';
 import { parseBearerToken, resolveMcpTokenUser } from '@/lib/mcp/tokens';
 import { logDuration, startTimer } from '@/utils/performance-logger';
 
 export const dynamic = 'force-dynamic';
 
-/** Advertised so clients know which auth scheme to use on a 401. */
-const AUTH_CHALLENGE = 'Bearer realm="Roster Loom MCP", error="invalid_token"';
-
 /**
- * Supabase client for MCP requests.
- *
- * Prefers the service role key when configured, since MCP callers
- * authenticate with their own token rather than a Supabase session and
- * so carry no `auth.uid()`. Falls back to the anon key, which matches
- * how the existing bearer-authenticated `/api/teams/refresh` path
- * queries. Either way every query is explicitly scoped by user id.
+ * Advertised so clients know which auth scheme to use on a 401, and
+ * (per RFC 9728) where to discover the OAuth metadata that lets a
+ * client register and authorize itself instead of requiring a
+ * hand-pasted token.
  */
-function createMcpSupabaseClient() {
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+async function authChallenge(): Promise<string> {
+  const origin = await resolveOrigin();
+  const resourceMetadataUrl = origin
+    ? `${origin}/.well-known/oauth-protected-resource/api/mcp`
+    : '/.well-known/oauth-protected-resource/api/mcp';
 
-  return createSupabaseClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    serviceRoleKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      auth: {
-        persistSession: false,
-        autoRefreshToken: false,
-        detectSessionInUrl: false,
-      },
-    },
-  );
+  return `Bearer realm="Roster Loom MCP", error="invalid_token", resource_metadata="${resourceMetadataUrl}"`;
 }
 
 function jsonResponse(body: unknown, status: number, protocolVersion: string) {
@@ -76,20 +67,20 @@ export async function POST(request: Request) {
   if (!token) {
     return NextResponse.json(
       { error: 'Missing bearer token. Create one at /mcp.' },
-      { status: 401, headers: { 'WWW-Authenticate': AUTH_CHALLENGE } },
+      { status: 401, headers: { 'WWW-Authenticate': await authChallenge() } },
     );
   }
 
   const supabase = createMcpSupabaseClient();
 
   const authStart = startTimer();
-  const userId = await resolveMcpTokenUser(supabase, token);
+  const userId = (await resolveMcpTokenUser(supabase, token)) ?? (await resolveOAuthAccessTokenUser(supabase, token));
   logDuration('mcp: authenticate token', authStart, { authenticated: Boolean(userId) });
 
   if (!userId) {
     return NextResponse.json(
-      { error: 'Invalid or revoked token.' },
-      { status: 401, headers: { 'WWW-Authenticate': AUTH_CHALLENGE } },
+      { error: 'Invalid, expired, or revoked token.' },
+      { status: 401, headers: { 'WWW-Authenticate': await authChallenge() } },
     );
   }
 

--- a/apps/web/src/app/api/mcp/token/route.ts
+++ b/apps/web/src/app/api/mcp/token/route.ts
@@ -1,0 +1,97 @@
+/**
+ * OAuth token endpoint: exchanges an authorization code (with its PKCE
+ * verifier) for an access/refresh token pair, or rotates a refresh
+ * token for a fresh pair. See docs/MCP.md.
+ */
+import { NextResponse } from 'next/server';
+
+import { exchangeAuthorizationCode, getOAuthClient, issueOAuthTokens, rotateOAuthTokens } from '@/lib/mcp/oauth';
+import { createMcpSupabaseClient } from '@/lib/mcp/supabase';
+
+export const dynamic = 'force-dynamic';
+
+function errorResponse(error: string, description: string, status = 400) {
+  return NextResponse.json({ error, error_description: description }, { status });
+}
+
+/** Reads token endpoint params from either form-urlencoded or JSON bodies. */
+async function readParams(request: Request): Promise<Record<string, string>> {
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    const body = await request.json().catch(() => ({}));
+    return typeof body === 'object' && body !== null ? (body as Record<string, string>) : {};
+  }
+
+  const form = await request.formData();
+  const params: Record<string, string> = {};
+  for (const [key, value] of form.entries()) {
+    if (typeof value === 'string') {
+      params[key] = value;
+    }
+  }
+  return params;
+}
+
+export async function POST(request: Request) {
+  const params = await readParams(request);
+  const supabase = createMcpSupabaseClient();
+
+  if (params.grant_type === 'authorization_code') {
+    const { code, redirect_uri: redirectUri, client_id: clientId, code_verifier: codeVerifier } = params;
+
+    if (!code || !redirectUri || !clientId || !codeVerifier) {
+      return errorResponse(
+        'invalid_request',
+        'code, redirect_uri, client_id and code_verifier are all required.',
+      );
+    }
+
+    const result = await exchangeAuthorizationCode(supabase, {
+      code,
+      redirectUri,
+      clientId,
+      codeVerifier,
+    });
+
+    if (!result.ok) {
+      return errorResponse(result.error, 'The authorization code is invalid, expired, or already used.');
+    }
+
+    const tokens = await issueOAuthTokens(supabase, { userId: result.userId, clientId });
+
+    return NextResponse.json({
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      token_type: 'Bearer',
+      expires_in: tokens.expiresIn,
+    });
+  }
+
+  if (params.grant_type === 'refresh_token') {
+    const { refresh_token: refreshToken, client_id: clientId } = params;
+
+    if (!refreshToken || !clientId) {
+      return errorResponse('invalid_request', 'refresh_token and client_id are both required.');
+    }
+
+    const client = await getOAuthClient(supabase, clientId);
+    if (!client) {
+      return errorResponse('invalid_client', 'Unknown client_id.');
+    }
+
+    const tokens = await rotateOAuthTokens(supabase, refreshToken, clientId);
+    if (!tokens) {
+      return errorResponse('invalid_grant', 'The refresh token is invalid, revoked, or belongs to a different client.');
+    }
+
+    return NextResponse.json({
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      token_type: 'Bearer',
+      expires_in: tokens.expiresIn,
+    });
+  }
+
+  return errorResponse('unsupported_grant_type', 'Only authorization_code and refresh_token grants are supported.');
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/utils/supabase/client';
 import { Input } from '@/components/ui/input';
@@ -15,9 +15,17 @@ import { AppNavigation } from '@/components/app-navigation';
  */
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  // Lets /mcp/authorize send an unauthenticated visitor here and land
+  // back on the consent screen after they sign in, instead of losing
+  // the in-progress OAuth request. Only ever a same-origin relative
+  // path — never followed if it isn't one.
+  const next = searchParams.get('next');
+  const redirectTo = next && next.startsWith('/') && !next.startsWith('//') ? next : '/';
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -27,7 +35,7 @@ export default function LoginPage() {
     if (error) {
       setError(error.message);
     } else {
-      router.replace('/');
+      router.replace(redirectTo);
     }
   };
 

--- a/apps/web/src/app/mcp/authorize/actions.ts
+++ b/apps/web/src/app/mcp/authorize/actions.ts
@@ -1,0 +1,55 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+import { createAuthorizationCode, getOAuthClient } from '@/lib/mcp/oauth';
+import { createClient } from '@/utils/supabase/server';
+
+/**
+ * Handles the user's decision on the /mcp/authorize consent screen:
+ * approve issues a single-use authorization code and sends the browser
+ * back to the client's redirect_uri; deny sends it back with an
+ * `access_denied` error instead. Both are safe redirect targets because
+ * the page already validated redirect_uri against the client's
+ * registered list before rendering the form this action is bound to.
+ */
+export async function decideAuthorization(formData: FormData): Promise<void> {
+  const decision = formData.get('decision');
+  const clientId = String(formData.get('client_id') ?? '');
+  const redirectUri = String(formData.get('redirect_uri') ?? '');
+  const codeChallenge = String(formData.get('code_challenge') ?? '');
+  const state = formData.get('state');
+
+  const client = await getOAuthClient(createClient(), clientId);
+  if (!client || !client.redirectUris.includes(redirectUri)) {
+    throw new Error('Invalid authorization request.');
+  }
+
+  const target = new URL(redirectUri);
+
+  if (decision !== 'approve') {
+    target.searchParams.set('error', 'access_denied');
+    if (typeof state === 'string' && state) target.searchParams.set('state', state);
+    redirect(target.toString());
+  }
+
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error('You must be logged in to authorize a client.');
+  }
+
+  const code = await createAuthorizationCode(supabase, {
+    clientId,
+    userId: user.id,
+    redirectUri,
+    codeChallenge,
+  });
+
+  target.searchParams.set('code', code);
+  if (typeof state === 'string' && state) target.searchParams.set('state', state);
+  redirect(target.toString());
+}

--- a/apps/web/src/app/mcp/authorize/page.tsx
+++ b/apps/web/src/app/mcp/authorize/page.tsx
@@ -1,0 +1,102 @@
+import { redirect } from 'next/navigation';
+
+import { AppNavigation } from '@/components/app-navigation';
+import { Button } from '@/components/ui/button';
+import { getOAuthClient } from '@/lib/mcp/oauth';
+import { createClient } from '@/utils/supabase/server';
+
+import { decideAuthorization } from './actions';
+
+export const dynamic = 'force-dynamic';
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function param(searchParams: SearchParams, key: string): string {
+  const value = searchParams[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function ErrorPage({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex flex-1 items-center justify-center p-4">
+        <p className="max-w-sm rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+          {message}
+        </p>
+      </main>
+    </div>
+  );
+}
+
+/**
+ * The consent screen a DCR client redirects a user to. Validates the
+ * request against the registered client before rendering anything —
+ * only once redirect_uri is confirmed to belong to client_id is it safe
+ * to send the browser back there, whether the user approves or denies.
+ */
+export default async function AuthorizePage({ searchParams }: { searchParams: SearchParams }) {
+  const responseType = param(searchParams, 'response_type');
+  const clientId = param(searchParams, 'client_id');
+  const redirectUri = param(searchParams, 'redirect_uri');
+  const codeChallenge = param(searchParams, 'code_challenge');
+  const codeChallengeMethod = param(searchParams, 'code_challenge_method');
+  const state = param(searchParams, 'state');
+
+  if (responseType !== 'code' || !clientId || !redirectUri || !codeChallenge) {
+    return (
+      <ErrorPage message="Malformed authorization request: response_type, client_id, redirect_uri and code_challenge are all required." />
+    );
+  }
+
+  if (codeChallengeMethod !== 'S256') {
+    return <ErrorPage message="This server only supports PKCE with code_challenge_method=S256." />;
+  }
+
+  const client = await getOAuthClient(createClient(), clientId);
+  if (!client || !client.redirectUris.includes(redirectUri)) {
+    return <ErrorPage message="Unknown client, or redirect_uri does not match its registration." />;
+  }
+
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(searchParams)) {
+      if (typeof value === 'string') query.set(key, value);
+    }
+    redirect(`/login?next=${encodeURIComponent(`/mcp/authorize?${query.toString()}`)}`);
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <AppNavigation />
+      <main className="flex flex-1 items-center justify-center p-4">
+        <div className="w-full max-w-sm space-y-6 rounded-md border p-6">
+          <div className="space-y-2">
+            <h1 className="text-xl font-semibold">Authorize {client.clientName}</h1>
+            <p className="text-sm text-muted-foreground">
+              This app wants read-only access to your Roster Loom leagues, rosters and
+              live matchups, signed in as <span className="font-medium">{user.email}</span>.
+            </p>
+          </div>
+          <form action={decideAuthorization} className="flex gap-3">
+            <input type="hidden" name="client_id" value={clientId} />
+            <input type="hidden" name="redirect_uri" value={redirectUri} />
+            <input type="hidden" name="code_challenge" value={codeChallenge} />
+            <input type="hidden" name="state" value={state} />
+            <Button type="submit" name="decision" value="deny" variant="outline" className="flex-1">
+              Deny
+            </Button>
+            <Button type="submit" name="decision" value="approve" className="flex-1">
+              Approve
+            </Button>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/lib/mcp/oauth.test.ts
+++ b/apps/web/src/lib/mcp/oauth.test.ts
@@ -1,0 +1,182 @@
+import { createHash } from 'crypto';
+
+import {
+  computeCodeChallengeS256,
+  exchangeAuthorizationCode,
+  getOAuthClient,
+  registerOAuthClient,
+  resolveOAuthAccessTokenUser,
+  rotateOAuthTokens,
+} from './oauth';
+
+/** Builds a fake SupabaseClient whose `.rpc()` resolves `response`, and
+ * whose result also answers `.maybeSingle()` with the same response, so
+ * both calling styles used across oauth.ts work against one mock. */
+function client(response: { data?: unknown; error?: unknown }) {
+  const rpc = jest.fn().mockReturnValue({
+    data: response.data,
+    error: response.error,
+    maybeSingle: () => Promise.resolve(response),
+  });
+  return { rpc } as never;
+}
+
+describe('computeCodeChallengeS256', () => {
+  it('matches the RFC 7636 base64url(sha256(verifier)) construction', () => {
+    const verifier = 'a-random-code-verifier';
+    const expected = createHash('sha256').update(verifier, 'ascii').digest('base64url');
+
+    expect(computeCodeChallengeS256(verifier)).toBe(expected);
+  });
+});
+
+describe('registerOAuthClient', () => {
+  it('registers a client and returns it with a generated id', async () => {
+    const supabase = client({ data: null, error: null });
+
+    const registered = await registerOAuthClient(supabase, 'My App', ['https://app.example/cb']);
+
+    expect(registered.clientId.startsWith('rl_mcp_client_')).toBe(true);
+    expect(registered.clientName).toBe('My App');
+    expect(registered.redirectUris).toEqual(['https://app.example/cb']);
+    expect((supabase as never as { rpc: jest.Mock }).rpc).toHaveBeenCalledWith(
+      'fp_mcp_oauth_register_client',
+      expect.objectContaining({ p_client_name: 'My App', p_redirect_uris: ['https://app.example/cb'] }),
+    );
+  });
+
+  it('throws when the database call fails', async () => {
+    const supabase = client({ data: null, error: { message: 'boom' } });
+
+    await expect(registerOAuthClient(supabase, 'My App', ['https://app.example/cb'])).rejects.toThrow(
+      'boom',
+    );
+  });
+});
+
+describe('getOAuthClient', () => {
+  it('returns the client on a match', async () => {
+    const supabase = client({
+      data: { client_id: 'c1', client_name: 'My App', redirect_uris: ['https://app.example/cb'] },
+      error: null,
+    });
+
+    await expect(getOAuthClient(supabase, 'c1')).resolves.toEqual({
+      clientId: 'c1',
+      clientName: 'My App',
+      redirectUris: ['https://app.example/cb'],
+    });
+  });
+
+  it('returns null when unknown', async () => {
+    const supabase = client({ data: null, error: null });
+
+    await expect(getOAuthClient(supabase, 'nope')).resolves.toBeNull();
+  });
+});
+
+describe('resolveOAuthAccessTokenUser', () => {
+  it('rejects tokens without the OAuth access-token prefix without querying', async () => {
+    const supabase = client({ data: 'user-1', error: null });
+
+    await expect(resolveOAuthAccessTokenUser(supabase, 'rl_mcp_not_an_at')).resolves.toBeNull();
+    expect((supabase as never as { rpc: jest.Mock }).rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns the owning user id for a valid token', async () => {
+    const supabase = client({ data: 'user-1', error: null });
+
+    await expect(resolveOAuthAccessTokenUser(supabase, 'rl_mcp_at_abc')).resolves.toBe('user-1');
+  });
+
+  it('returns null when expired or revoked', async () => {
+    const supabase = client({ data: null, error: null });
+
+    await expect(resolveOAuthAccessTokenUser(supabase, 'rl_mcp_at_abc')).resolves.toBeNull();
+  });
+});
+
+describe('exchangeAuthorizationCode', () => {
+  const baseRow = {
+    client_id: 'c1',
+    user_id: 'user-1',
+    redirect_uri: 'https://app.example/cb',
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    used_at: null as string | null,
+  };
+
+  it('rejects a mismatched PKCE verifier without consuming the code', async () => {
+    const supabase = client({ data: { ...baseRow, code_challenge: 'expected-challenge' }, error: null });
+
+    const result = await exchangeAuthorizationCode(supabase, {
+      code: 'code-1',
+      clientId: 'c1',
+      redirectUri: 'https://app.example/cb',
+      codeVerifier: 'wrong-verifier',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'invalid_grant' });
+  });
+
+  it('succeeds and consumes the code when everything matches', async () => {
+    const verifier = 'correct-verifier';
+    const challenge = computeCodeChallengeS256(verifier);
+
+    const rpc = jest
+      .fn()
+      .mockReturnValueOnce({ maybeSingle: () => Promise.resolve({ data: { ...baseRow, code_challenge: challenge }, error: null }) })
+      .mockReturnValueOnce(Promise.resolve({ data: true, error: null }));
+
+    const supabase = { rpc } as never;
+
+    const result = await exchangeAuthorizationCode(supabase, {
+      code: 'code-1',
+      clientId: 'c1',
+      redirectUri: 'https://app.example/cb',
+      codeVerifier: verifier,
+    });
+
+    expect(result).toEqual({ ok: true, userId: 'user-1' });
+  });
+
+  it('rejects an already-used code', async () => {
+    const supabase = client({
+      data: { ...baseRow, used_at: new Date().toISOString(), code_challenge: 'x' },
+      error: null,
+    });
+
+    const result = await exchangeAuthorizationCode(supabase, {
+      code: 'code-1',
+      clientId: 'c1',
+      redirectUri: 'https://app.example/cb',
+      codeVerifier: 'whatever',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'invalid_grant' });
+  });
+});
+
+describe('rotateOAuthTokens', () => {
+  it('rejects tokens without the refresh-token prefix without querying', async () => {
+    const supabase = client({ data: null, error: null });
+
+    await expect(rotateOAuthTokens(supabase, 'not-a-refresh-token', 'c1')).resolves.toBeNull();
+    expect((supabase as never as { rpc: jest.Mock }).rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the client_id does not match the token owner', async () => {
+    const supabase = client({ data: { user_id: 'user-1', client_id: 'other-client' }, error: null });
+
+    await expect(rotateOAuthTokens(supabase, 'rl_mcp_rt_abc', 'c1')).resolves.toBeNull();
+  });
+
+  it('returns a fresh token pair on success', async () => {
+    const supabase = client({ data: { user_id: 'user-1', client_id: 'c1' }, error: null });
+
+    const tokens = await rotateOAuthTokens(supabase, 'rl_mcp_rt_abc', 'c1');
+
+    expect(tokens?.accessToken.startsWith('rl_mcp_at_')).toBe(true);
+    expect(tokens?.refreshToken.startsWith('rl_mcp_rt_')).toBe(true);
+    expect(tokens?.expiresIn).toBe(3600);
+  });
+});

--- a/apps/web/src/lib/mcp/oauth.ts
+++ b/apps/web/src/lib/mcp/oauth.ts
@@ -1,0 +1,321 @@
+/**
+ * OAuth 2.0 Dynamic Client Registration (RFC 7591) + authorization code
+ * flow with PKCE (RFC 7636) for the hosted MCP server.
+ *
+ * This is the "discover, self-register, redirect through login" path
+ * that connector UIs (e.g. Claude.ai's remote MCP connector) require,
+ * sitting alongside the manual personal-access-token flow in tokens.ts.
+ * Clients are always public (no client_secret) — PKCE is mandatory
+ * instead, matching what the MCP auth spec expects of native/desktop/
+ * web clients that can't hold a secret safely.
+ *
+ * All lookups run through the SECURITY DEFINER functions added in
+ * supabase/migrations/20260823120000_add_fp_mcp_oauth.sql, since these
+ * endpoints are reached by callers with no Supabase session.
+ */
+import { createHash, randomBytes } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Prefix for dynamically registered client ids. */
+const CLIENT_ID_PREFIX = 'rl_mcp_client_';
+/** Prefix for authorization codes. */
+const CODE_PREFIX = 'rl_mcp_code_';
+/** Prefix for OAuth-issued access tokens (distinct from manual PATs). */
+const ACCESS_TOKEN_PREFIX = 'rl_mcp_at_';
+/** Prefix for OAuth refresh tokens. */
+const REFRESH_TOKEN_PREFIX = 'rl_mcp_rt_';
+
+/** How long an authorization code is valid for before it must be exchanged. */
+const CODE_TTL_MS = 5 * 60 * 1000;
+/** How long an access token is valid for before it must be refreshed. */
+const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+
+function randomToken(prefix: string): string {
+  return `${prefix}${randomBytes(32).toString('base64url')}`;
+}
+
+function hash(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+/** A registered OAuth client. */
+export type OAuthClient = {
+  clientId: string;
+  clientName: string;
+  redirectUris: string[];
+};
+
+/**
+ * Registers a new dynamic client (RFC 7591). Registration is open — no
+ * admin approval — since a connector UI calls this the first time a
+ * user adds the server, before any human is in the loop.
+ *
+ * @param supabase - Service-role (or anon) Supabase client.
+ * @param clientName - Human-readable name from the client's metadata.
+ * @param redirectUris - Redirect URIs the client may be sent back to.
+ * @returns The newly registered client.
+ */
+export async function registerOAuthClient(
+  supabase: SupabaseClient,
+  clientName: string,
+  redirectUris: string[],
+): Promise<OAuthClient> {
+  const clientId = randomToken(CLIENT_ID_PREFIX);
+
+  const { error } = await supabase.rpc('fp_mcp_oauth_register_client', {
+    p_client_id: clientId,
+    p_client_name: clientName,
+    p_redirect_uris: redirectUris,
+  });
+
+  if (error) {
+    throw new Error(`Failed to register OAuth client: ${error.message}`);
+  }
+
+  return { clientId, clientName, redirectUris };
+}
+
+/**
+ * Looks up a registered client, for validating /authorize and /token
+ * requests (redirect_uri match, client existence).
+ *
+ * @param supabase - Service-role (or anon) Supabase client.
+ * @param clientId - The client id presented by the caller.
+ * @returns The client, or `null` if unknown.
+ */
+export async function getOAuthClient(
+  supabase: SupabaseClient,
+  clientId: string,
+): Promise<OAuthClient | null> {
+  const { data, error } = await supabase
+    .rpc('fp_mcp_oauth_get_client', { p_client_id: clientId })
+    .maybeSingle();
+
+  if (error || !data) {
+    return null;
+  }
+
+  const row = data as { client_id: string; client_name: string; redirect_uris: string[] | null };
+
+  return {
+    clientId: row.client_id,
+    clientName: row.client_name,
+    redirectUris: row.redirect_uris ?? [],
+  };
+}
+
+/**
+ * Computes the PKCE `S256` code challenge for a verifier, per RFC 7636:
+ * base64url(sha256(verifier)).
+ *
+ * @param verifier - The `code_verifier` presented at the token endpoint.
+ * @returns The expected `code_challenge`.
+ */
+export function computeCodeChallengeS256(verifier: string): string {
+  return createHash('sha256').update(verifier, 'ascii').digest('base64url');
+}
+
+/**
+ * Creates and stores an authorization code once a logged-in user
+ * approves a client at /mcp/authorize. Runs under the user's own
+ * Supabase session (RLS: insert own).
+ *
+ * @param supabase - A Supabase client carrying the user's session.
+ * @param params - The client, user, redirect URI and PKCE challenge to bind the code to.
+ * @returns The plaintext code to append to the redirect.
+ */
+export async function createAuthorizationCode(
+  supabase: SupabaseClient,
+  params: {
+    clientId: string;
+    userId: string;
+    redirectUri: string;
+    codeChallenge: string;
+  },
+): Promise<string> {
+  const code = randomToken(CODE_PREFIX);
+
+  const { error } = await supabase.from('fp_mcp_oauth_codes').insert({
+    code_hash: hash(code),
+    client_id: params.clientId,
+    user_id: params.userId,
+    redirect_uri: params.redirectUri,
+    code_challenge: params.codeChallenge,
+    expires_at: new Date(Date.now() + CODE_TTL_MS).toISOString(),
+  });
+
+  if (error) {
+    throw new Error(`Failed to create authorization code: ${error.message}`);
+  }
+
+  return code;
+}
+
+export type CodeExchangeResult =
+  | { ok: true; userId: string }
+  | { ok: false; error: string };
+
+/**
+ * Validates and consumes an authorization code at the token endpoint:
+ * checks the client, redirect URI and PKCE verifier match, then atomically
+ * marks the code used so it can never be replayed.
+ *
+ * @param supabase - Service-role (or anon) Supabase client.
+ * @param params - The code and the values the client presents alongside it.
+ * @returns The owning user id, or an error describing why the exchange failed.
+ */
+export async function exchangeAuthorizationCode(
+  supabase: SupabaseClient,
+  params: { code: string; clientId: string; redirectUri: string; codeVerifier: string },
+): Promise<CodeExchangeResult> {
+  const codeHash = hash(params.code);
+
+  const { data, error } = await supabase
+    .rpc('fp_mcp_oauth_peek_code', { p_code_hash: codeHash })
+    .maybeSingle();
+
+  if (error || !data) {
+    return { ok: false, error: 'invalid_grant' };
+  }
+
+  const row = data as {
+    client_id: string;
+    user_id: string;
+    redirect_uri: string;
+    code_challenge: string;
+    expires_at: string;
+    used_at: string | null;
+  };
+
+  if (row.used_at || new Date(row.expires_at).getTime() <= Date.now()) {
+    return { ok: false, error: 'invalid_grant' };
+  }
+
+  if (row.client_id !== params.clientId || row.redirect_uri !== params.redirectUri) {
+    return { ok: false, error: 'invalid_grant' };
+  }
+
+  if (computeCodeChallengeS256(params.codeVerifier) !== row.code_challenge) {
+    return { ok: false, error: 'invalid_grant' };
+  }
+
+  const { data: consumed, error: consumeError } = await supabase.rpc(
+    'fp_mcp_oauth_consume_code',
+    { p_code_hash: codeHash },
+  );
+
+  if (consumeError || !consumed) {
+    return { ok: false, error: 'invalid_grant' };
+  }
+
+  return { ok: true, userId: row.user_id };
+}
+
+/** A freshly minted or rotated access/refresh token pair. */
+export type OAuthTokenPair = {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+};
+
+/**
+ * Issues the first access/refresh pair after a successful code exchange.
+ *
+ * @param supabase - Service-role (or anon) Supabase client.
+ * @param params - The user and client the tokens belong to.
+ * @returns The plaintext token pair.
+ */
+export async function issueOAuthTokens(
+  supabase: SupabaseClient,
+  params: { userId: string; clientId: string },
+): Promise<OAuthTokenPair> {
+  const accessToken = randomToken(ACCESS_TOKEN_PREFIX);
+  const refreshToken = randomToken(REFRESH_TOKEN_PREFIX);
+  const expiresAt = new Date(Date.now() + ACCESS_TOKEN_TTL_SECONDS * 1000);
+
+  const { error } = await supabase.rpc('fp_mcp_oauth_issue_tokens', {
+    p_user_id: params.userId,
+    p_client_id: params.clientId,
+    p_access_hash: hash(accessToken),
+    p_refresh_hash: hash(refreshToken),
+    p_expires_at: expiresAt.toISOString(),
+  });
+
+  if (error) {
+    throw new Error(`Failed to issue OAuth tokens: ${error.message}`);
+  }
+
+  return { accessToken, refreshToken, expiresIn: ACCESS_TOKEN_TTL_SECONDS };
+}
+
+/**
+ * Rotates a refresh token: the old refresh token stops working the
+ * instant this succeeds, whether or not the caller was the legitimate
+ * client (protects against a stolen-then-replayed refresh token, since
+ * the real client's next refresh attempt will also fail and surface the
+ * compromise).
+ *
+ * @param supabase - Service-role (or anon) Supabase client.
+ * @param refreshToken - The plaintext refresh token presented by the client.
+ * @param clientId - The client id presented alongside it; must match the token's owner.
+ * @returns The new token pair, or `null` if the refresh token is invalid, expired-out, or belongs to a different client.
+ */
+export async function rotateOAuthTokens(
+  supabase: SupabaseClient,
+  refreshToken: string,
+  clientId: string,
+): Promise<OAuthTokenPair | null> {
+  if (!refreshToken.startsWith(REFRESH_TOKEN_PREFIX)) {
+    return null;
+  }
+
+  const newAccessToken = randomToken(ACCESS_TOKEN_PREFIX);
+  const newRefreshToken = randomToken(REFRESH_TOKEN_PREFIX);
+  const expiresAt = new Date(Date.now() + ACCESS_TOKEN_TTL_SECONDS * 1000);
+
+  const { data, error } = await supabase
+    .rpc('fp_mcp_oauth_rotate_refresh_token', {
+      p_old_refresh_hash: hash(refreshToken),
+      p_new_access_hash: hash(newAccessToken),
+      p_new_refresh_hash: hash(newRefreshToken),
+      p_expires_at: expiresAt.toISOString(),
+    })
+    .maybeSingle();
+
+  const row = data as { user_id: string; client_id: string } | null;
+
+  if (error || !row || row.client_id !== clientId) {
+    return null;
+  }
+
+  return { accessToken: newAccessToken, refreshToken: newRefreshToken, expiresIn: ACCESS_TOKEN_TTL_SECONDS };
+}
+
+/**
+ * Resolves an OAuth access token to its owning user, mirroring
+ * `resolveMcpTokenUser` in tokens.ts but for tokens minted via this
+ * flow (checked for expiry, not just revocation).
+ *
+ * @param supabase - Service-role (or anon) Supabase client.
+ * @param token - The plaintext bearer token presented by the caller.
+ * @returns The owning user id, or `null` if the token isn't an OAuth access token, or is unknown/expired/revoked.
+ */
+export async function resolveOAuthAccessTokenUser(
+  supabase: SupabaseClient,
+  token: string,
+): Promise<string | null> {
+  if (!token.startsWith(ACCESS_TOKEN_PREFIX)) {
+    return null;
+  }
+
+  const { data, error } = await supabase.rpc('fp_mcp_oauth_access_token_owner', {
+    p_token_hash: hash(token),
+  });
+
+  if (error) {
+    console.error('Failed to resolve OAuth access token', error.message);
+    return null;
+  }
+
+  return typeof data === 'string' && data ? data : null;
+}

--- a/apps/web/src/lib/mcp/server-url.ts
+++ b/apps/web/src/lib/mcp/server-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolves the absolute origin of the running deployment from request
+ * headers, so OAuth metadata and redirect URLs are correct in local dev,
+ * preview and production alike.
+ */
+import { headers } from 'next/headers';
+
+export async function resolveOrigin(): Promise<string> {
+  const headerList = await headers();
+  const host = headerList.get('host');
+
+  if (!host) {
+    return '';
+  }
+
+  const forwardedProto = headerList.get('x-forwarded-proto');
+  const protocol =
+    forwardedProto?.split(',')[0]?.trim() ||
+    (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https');
+
+  return `${protocol}://${host}`;
+}

--- a/apps/web/src/lib/mcp/supabase.ts
+++ b/apps/web/src/lib/mcp/supabase.ts
@@ -1,0 +1,29 @@
+/**
+ * Supabase client for MCP endpoints reached by an unauthenticated
+ * caller — the JSON-RPC endpoint itself, and the OAuth register/token
+ * endpoints in the DCR flow. None of these carry a Supabase session, so
+ * there is no `auth.uid()` to scope queries with the way a normal
+ * server action can.
+ *
+ * Prefers the service role key when configured, falling back to the
+ * anon key (which still works: every table these endpoints touch is
+ * reachable only through SECURITY DEFINER functions or is explicitly
+ * scoped by user id in application code).
+ */
+import { createClient as createSupabaseClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export function createMcpSupabaseClient(): SupabaseClient {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
+  );
+}

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -13,8 +13,9 @@ POST https://<your-deployment>/api/mcp
 
 ## Setup
 
-The server needs the `fp_mcp_tokens` table and its lookup function, so
-apply the migrations to the linked project once before first use:
+The server needs the `fp_mcp_tokens` and `fp_mcp_oauth_*` tables and
+their lookup functions, so apply the migrations to the linked project
+once before first use:
 
 ```bash
 npx supabase db push
@@ -32,18 +33,21 @@ scoped by user id.
 
 ## Connecting a client
 
+Two ways to authenticate, depending on what the client supports:
+
+### Personal access token
+
+For clients that let you paste a static bearer token into their config
+(Claude Code, `claude_desktop_config.json`):
+
 1. Sign in and open **/mcp**.
 2. Create an access token and copy it — it is shown once.
 3. Point your client at the endpoint with the token as a bearer header.
-
-Claude Code:
 
 ```bash
 claude mcp add --transport http roster-loom https://<your-deployment>/api/mcp \
   --header "Authorization: Bearer rl_mcp_..."
 ```
-
-`claude_desktop_config.json`:
 
 ```json
 {
@@ -57,8 +61,25 @@ claude mcp add --transport http roster-loom https://<your-deployment>/api/mcp \
 }
 ```
 
-Locally, the dev server on port 9002 serves the same endpoint at
-`http://localhost:9002/api/mcp`.
+### OAuth (Dynamic Client Registration)
+
+For connector UIs that only take a server URL and don't offer a place
+to paste a token (e.g. Claude.ai's remote MCP connector), point the
+client at `https://<your-deployment>/api/mcp` with no header. It
+discovers everything else itself:
+
+1. `GET /.well-known/oauth-protected-resource/api/mcp` — resolved from
+   the `resource_metadata` param on the endpoint's `401`.
+2. `GET /.well-known/oauth-authorization-server` — the authorization,
+   token and registration endpoints.
+3. `POST /api/mcp/register` — self-registers as a client (RFC 7591).
+4. Redirects the user's browser to `/mcp/authorize` (PKCE, `S256`
+   required); the user signs in if needed and approves the client.
+5. `POST /api/mcp/token` — exchanges the resulting code for an access
+   token, and later refreshes it.
+
+Locally, the dev server on port 9002 serves the same endpoints at
+`http://localhost:9002`.
 
 ## Tools
 
@@ -78,26 +99,47 @@ from an earlier answer is a likely mistake.
 
 ## Authentication
 
-MCP clients store a static string in their config, so Supabase's
-hour-long access tokens are unusable here. Instead `/mcp` mints
-long-lived personal access tokens:
+Two token flows feed the same `Authorization: Bearer <token>` check in
+`/api/mcp`.
+
+**Personal access tokens** — for clients that store a static string in
+their config, where Supabase's hour-long access tokens are unusable:
 
 - The token is `rl_mcp_` + 32 random bytes.
 - Only its SHA-256 is stored, in `fp_mcp_tokens`. The plaintext is shown
   once and is unrecoverable.
-- Requests present it as `Authorization: Bearer <token>`.
 - Verification goes through the `fp_mcp_token_owner` SECURITY DEFINER
   function, which resolves the hash to a user id and stamps
   `last_used_at`.
 - Revoking sets `revoked_at`, which takes effect on the next request.
+- Non-expiring until revoked.
 
-`fp_mcp_tokens` is the one table in this schema with RLS enabled — a user
-can only ever see and manage their own tokens. Unlike the other `fp_`
-tables it holds credential material, so it does not inherit their
-open-by-default posture.
+**OAuth (DCR)** — for connector UIs that run an authorization-code +
+PKCE flow instead (see [Connecting a client](#connecting-a-client)):
 
-A token grants read access to everything the owning account can see.
-Treat it like a password, and revoke it at `/mcp` if it leaks.
+- `fp_mcp_oauth_clients` holds dynamically registered clients
+  (`rl_mcp_client_...`), all public — no client secret, since PKCE
+  (`S256`) is mandatory instead.
+- `fp_mcp_oauth_codes` holds single-use authorization codes
+  (`rl_mcp_code_...`), 5-minute lifetime, bound to the approving user,
+  the client, the redirect URI and the PKCE challenge.
+- `fp_mcp_oauth_tokens` holds access (`rl_mcp_at_...`) and refresh
+  (`rl_mcp_rt_...`) token pairs. Access tokens expire after 1 hour;
+  refreshing rotates both hashes on the same row in place, so a stale
+  refresh token — rotated-away or replayed — stops working immediately.
+- Implementation: `apps/web/src/lib/mcp/oauth.ts`.
+
+`fp_mcp_tokens` and the `fp_mcp_oauth_*` tables are the only tables in
+this schema with RLS enabled — unlike the other `fp_` tables, they hold
+credential material, so they don't inherit the open-by-default posture.
+Everything reachable by an unauthenticated caller (token/code
+verification, client registration) goes through a SECURITY DEFINER
+function rather than a table policy.
+
+Any of these tokens grants read access to everything the owning account
+can see. Treat them like a password, and revoke a leaked one at `/mcp`
+(personal access tokens) — an OAuth-issued token expires within the
+hour on its own if not refreshed.
 
 ## Transport
 
@@ -127,11 +169,19 @@ apps/web/src/lib/mcp/
 ├── protocol.ts     # JSON-RPC dispatch + Streamable HTTP semantics
 ├── tools.ts        # Tool definitions and handlers
 ├── views.ts        # Pure Team[] -> tool payload transforms
-└── tokens.ts       # Token minting, hashing, verification
+├── tokens.ts       # Personal access token minting, hashing, verification
+├── oauth.ts         # DCR client registration + auth code/PKCE + token issuance
+├── server-url.ts     # Origin resolution for metadata + redirect URLs
+└── supabase.ts       # Service-role client shared by the unauthenticated endpoints
 
-apps/web/src/app/api/mcp/route.ts        # HTTP layer: auth, data loading
-apps/web/src/app/(dashboard)/mcp/        # Token management UI
+apps/web/src/app/api/mcp/route.ts          # HTTP layer: auth, data loading
+apps/web/src/app/api/mcp/register/route.ts # DCR client registration
+apps/web/src/app/api/mcp/token/route.ts    # OAuth token exchange + refresh
+apps/web/src/app/mcp/authorize/            # OAuth consent screen
+apps/web/src/app/.well-known/              # OAuth AS + protected-resource metadata
+apps/web/src/app/(dashboard)/mcp/          # Token management UI
 supabase/migrations/*_add_fp_mcp_tokens.sql
+supabase/migrations/*_add_fp_mcp_oauth.sql
 ```
 
 Tools are pure functions of the `Team[]` that `getTeams()` already

--- a/supabase/migrations/20260823120000_add_fp_mcp_oauth.sql
+++ b/supabase/migrations/20260823120000_add_fp_mcp_oauth.sql
@@ -1,0 +1,239 @@
+-- OAuth 2.0 Dynamic Client Registration (RFC 7591) + authorization code
+-- flow with PKCE for the hosted MCP server (`POST /api/mcp`).
+--
+-- This sits alongside the existing `fp_mcp_tokens` personal access token
+-- flow (docs/MCP.md) rather than replacing it: PATs remain the "paste a
+-- token" path for clients like Claude Code, while this is the "discover,
+-- self-register, and redirect the user through login" path that
+-- connector UIs (e.g. Claude.ai's remote MCP connector) require.
+--
+-- Clients are public (no client_secret) per the MCP auth spec's
+-- expectation that native/desktop/web clients can't hold a secret
+-- safely; PKCE (S256) is mandatory instead.
+--
+-- All three tables are unauthenticated-caller surfaces (a DCR client has
+-- no Supabase session), so verification/consumption goes through
+-- SECURITY DEFINER functions, mirroring fp_mcp_token_owner.
+
+-- Dynamically registered OAuth clients.
+CREATE TABLE public.fp_mcp_oauth_clients (
+  client_id TEXT PRIMARY KEY,
+  client_name TEXT NOT NULL,
+  redirect_uris TEXT[] NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.fp_mcp_oauth_clients ENABLE ROW LEVEL SECURITY;
+-- No policies: only reachable via the SECURITY DEFINER functions below,
+-- or a service-role connection.
+
+-- Short-lived authorization codes issued at /mcp/authorize once a
+-- logged-in user approves a client. Single use.
+CREATE TABLE public.fp_mcp_oauth_codes (
+  code_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES public.fp_mcp_oauth_clients(client_id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  redirect_uri TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  used_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX fp_mcp_oauth_codes_user_id_idx ON public.fp_mcp_oauth_codes (user_id);
+
+ALTER TABLE public.fp_mcp_oauth_codes ENABLE ROW LEVEL SECURITY;
+
+-- Issuing a code happens on /mcp/authorize, where the caller *does*
+-- carry a real Supabase session, so this one path uses an ordinary RLS
+-- policy rather than a SECURITY DEFINER function.
+CREATE POLICY fp_mcp_oauth_codes_insert_own ON public.fp_mcp_oauth_codes
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+-- Access/refresh token pairs minted by the token endpoint. Refresh
+-- rotates in place: fp_mcp_oauth_rotate_refresh_token overwrites both
+-- hashes on the same row, so a stolen, already-rotated refresh token
+-- stops working the moment the legitimate client refreshes.
+CREATE TABLE public.fp_mcp_oauth_tokens (
+  id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  client_id TEXT NOT NULL REFERENCES public.fp_mcp_oauth_clients(client_id) ON DELETE CASCADE,
+  access_token_hash TEXT NOT NULL UNIQUE,
+  refresh_token_hash TEXT NOT NULL UNIQUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_used_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX fp_mcp_oauth_tokens_user_id_idx ON public.fp_mcp_oauth_tokens (user_id);
+
+ALTER TABLE public.fp_mcp_oauth_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY fp_mcp_oauth_tokens_select_own ON public.fp_mcp_oauth_tokens
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+-- Lets a user revoke an OAuth-connected app from /mcp, same as a PAT.
+CREATE POLICY fp_mcp_oauth_tokens_update_own ON public.fp_mcp_oauth_tokens
+  FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- Registers a new DCR client. Open registration (no admin approval) is
+-- what the MCP auth spec expects: a connector UI calls this the first
+-- time a user adds the server, with no human in the loop yet.
+CREATE OR REPLACE FUNCTION public.fp_mcp_oauth_register_client(
+  p_client_id TEXT,
+  p_client_name TEXT,
+  p_redirect_uris TEXT[]
+) RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  INSERT INTO public.fp_mcp_oauth_clients (client_id, client_name, redirect_uris)
+  VALUES (p_client_id, p_client_name, p_redirect_uris);
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_oauth_register_client(TEXT, TEXT, TEXT[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_oauth_register_client(TEXT, TEXT, TEXT[]) TO anon, authenticated;
+
+-- Looks up a registered client by id, for validating /authorize and
+-- /token requests (redirect_uri match, client existence).
+CREATE OR REPLACE FUNCTION public.fp_mcp_oauth_get_client(p_client_id TEXT)
+RETURNS TABLE (client_id TEXT, client_name TEXT, redirect_uris TEXT[])
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT client_id, client_name, redirect_uris
+    FROM public.fp_mcp_oauth_clients
+   WHERE client_id = p_client_id;
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_oauth_get_client(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_oauth_get_client(TEXT) TO anon, authenticated;
+
+-- Reads a pending code without consuming it, so the token endpoint can
+-- verify the PKCE challenge (computed in application code) before
+-- deciding whether to mark it used.
+CREATE OR REPLACE FUNCTION public.fp_mcp_oauth_peek_code(p_code_hash TEXT)
+RETURNS TABLE (
+  client_id TEXT,
+  user_id UUID,
+  redirect_uri TEXT,
+  code_challenge TEXT,
+  expires_at TIMESTAMPTZ,
+  used_at TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT client_id, user_id, redirect_uri, code_challenge, expires_at, used_at
+    FROM public.fp_mcp_oauth_codes
+   WHERE code_hash = p_code_hash;
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_oauth_peek_code(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_oauth_peek_code(TEXT) TO anon, authenticated;
+
+-- Atomically marks a code used (single-use enforcement); returns false
+-- if it was already consumed or never existed, so a replayed code can
+-- never succeed even under a race.
+CREATE OR REPLACE FUNCTION public.fp_mcp_oauth_consume_code(p_code_hash TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_updated BOOLEAN;
+BEGIN
+  UPDATE public.fp_mcp_oauth_codes
+     SET used_at = NOW()
+   WHERE code_hash = p_code_hash
+     AND used_at IS NULL
+     AND expires_at > NOW()
+  RETURNING TRUE INTO v_updated;
+
+  RETURN COALESCE(v_updated, FALSE);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_oauth_consume_code(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_oauth_consume_code(TEXT) TO anon, authenticated;
+
+-- Issues the first access/refresh pair after a successful code exchange.
+CREATE OR REPLACE FUNCTION public.fp_mcp_oauth_issue_tokens(
+  p_user_id UUID,
+  p_client_id TEXT,
+  p_access_hash TEXT,
+  p_refresh_hash TEXT,
+  p_expires_at TIMESTAMPTZ
+) RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  INSERT INTO public.fp_mcp_oauth_tokens
+    (user_id, client_id, access_token_hash, refresh_token_hash, expires_at)
+  VALUES (p_user_id, p_client_id, p_access_hash, p_refresh_hash, p_expires_at);
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_oauth_issue_tokens(UUID, TEXT, TEXT, TEXT, TIMESTAMPTZ) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_oauth_issue_tokens(UUID, TEXT, TEXT, TEXT, TIMESTAMPTZ) TO anon, authenticated;
+
+-- Resolves a presented OAuth access token to its owner, same shape as
+-- fp_mcp_token_owner but also enforcing expiry.
+CREATE OR REPLACE FUNCTION public.fp_mcp_oauth_access_token_owner(p_token_hash TEXT)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id UUID;
+BEGIN
+  UPDATE public.fp_mcp_oauth_tokens
+     SET last_used_at = NOW()
+   WHERE access_token_hash = p_token_hash
+     AND revoked_at IS NULL
+     AND expires_at > NOW()
+  RETURNING user_id INTO v_user_id;
+
+  RETURN v_user_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_oauth_access_token_owner(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_oauth_access_token_owner(TEXT) TO anon, authenticated;
+
+-- Rotates a refresh token: overwrites the access/refresh hashes on the
+-- matching row in place and returns who it belongs to. Returns no rows
+-- if the refresh token is unknown, already rotated, or revoked, which
+-- covers both expiry and replay of a stale token.
+CREATE OR REPLACE FUNCTION public.fp_mcp_oauth_rotate_refresh_token(
+  p_old_refresh_hash TEXT,
+  p_new_access_hash TEXT,
+  p_new_refresh_hash TEXT,
+  p_expires_at TIMESTAMPTZ
+) RETURNS TABLE (user_id UUID, client_id TEXT)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  UPDATE public.fp_mcp_oauth_tokens
+     SET access_token_hash = p_new_access_hash,
+         refresh_token_hash = p_new_refresh_hash,
+         expires_at = p_expires_at,
+         last_used_at = NOW()
+   WHERE refresh_token_hash = p_old_refresh_hash
+     AND revoked_at IS NULL
+  RETURNING user_id, client_id;
+$$;
+
+REVOKE ALL ON FUNCTION public.fp_mcp_oauth_rotate_refresh_token(TEXT, TEXT, TEXT, TIMESTAMPTZ) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fp_mcp_oauth_rotate_refresh_token(TEXT, TEXT, TEXT, TIMESTAMPTZ) TO anon, authenticated;


### PR DESCRIPTION
## Summary
- Adds RFC 7591 (DCR) + RFC 9728 (protected resource metadata) support to the hosted MCP server at `/api/mcp`, alongside the existing personal-access-token flow.
- Connector UIs that only take a server URL (no place to paste a token — e.g. Claude.ai's remote MCP connector) can now self-register a client, redirect the user through login + consent at `/mcp/authorize` (PKCE `S256` mandatory), and exchange the resulting code for a short-lived (1hr) access token + rotating refresh token.
- New tables: `fp_mcp_oauth_clients`, `fp_mcp_oauth_codes`, `fp_mcp_oauth_tokens`, all RLS-enabled with SECURITY DEFINER functions for the unauthenticated-caller surfaces (mirrors the existing `fp_mcp_tokens` pattern).
- `/api/mcp`'s 401 now advertises `resource_metadata` on `WWW-Authenticate` so OAuth-capable clients can discover the flow automatically; manual PATs keep working unchanged.
- Refactored the shared service-role Supabase client and origin-resolution helper out of `route.ts`/`mcp/page.tsx` into `lib/mcp/supabase.ts` and `lib/mcp/server-url.ts` so the new OAuth endpoints can reuse them.

## Test plan
- [x] `npm test` — full suite (213 web + 3 mobile), including new `apps/web/src/lib/mcp/oauth.test.ts` covering PKCE, client registration, code exchange, and refresh rotation.
- [x] `npm run lint` — no new warnings.
- [x] `npm run typecheck` — no new errors (remaining errors are pre-existing, unrelated to this change).
- [ ] Apply `supabase/migrations/20260823120000_add_fp_mcp_oauth.sql` to the linked project (`npx supabase db push`) before this is usable — not yet applied.
- [ ] End-to-end: register a client against `/api/mcp/register`, run the authorize/token exchange against a local dev server, confirm `/api/mcp` accepts the resulting access token and rejects it after expiry/revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FySBzvbbFsxnWGS62haEdk