### PR TITLE
fix(ottoneu): fall back to team roster table when no active matchup

### DIFF
--- a/apps/web/src/app/actions.test.ts
+++ b/apps/web/src/app/actions.test.ts
@@ -1091,6 +1091,65 @@ describe('actions', () => {
         score: 7.5,
       });
     });
+
+    it('falls back to the team roster table when there is no active matchup', async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+      mockSupabase.eq.mockResolvedValue({
+        data: [
+          { id: 1, provider: 'ottoneu', provider_user_id: '2514' },
+        ],
+        error: null,
+      });
+
+      const rosterHtml = `
+        <table class="sortable">
+          <thead><tr><th>Player</th><th>POS</th><th>Salary</th><th>Bye</th><th>2025 Pts</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><a href="https://ottoneu.fangraphs.com/football/309/player_card/nfl/7">Roster Guy</a> <span class="smaller">SF WR</span></td>
+              <td>WR</td>
+              <td>$10</td>
+              <td>9</td>
+              <td>50.00</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+
+      const sleeperPlayersData = {
+        '7': { full_name: 'Roster Guy', first_name: 'Roster', last_name: 'Guy', position: 'WR' },
+      } as Record<string, SleeperPlayer>;
+
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ week: 1 }) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockScoreboard) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(sleeperPlayersData) })
+        .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(rosterHtml) });
+
+      (getOttoneuLeagues as jest.Mock).mockResolvedValue({
+        leagues: [{ league_id: '309' }],
+        error: null,
+      });
+
+      (getOttoneuTeamInfo as jest.Mock).mockResolvedValue({
+        teamName: 'My Team',
+        teamId: '2514',
+      });
+
+      const result = await getTeams();
+
+      expect(result.teams).toHaveLength(1);
+      expect(result.teams[0].players).toHaveLength(1);
+      expect(result.teams[0].players[0]).toMatchObject({
+        id: '7',
+        name: 'Roster Guy',
+        position: 'WR',
+        realTeam: 'SF',
+        score: 0,
+        onBench: false,
+      });
+      expect(result.teams[0].opponent.players).toHaveLength(0);
+    });
   });
 
   describe('getTeams execution', () => {

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -908,6 +908,93 @@ export async function buildYahooTeams(
 }
 
 /**
+ * Fetches a team's full roster from its Ottoneu team page. Unlike the
+ * matchup/game page, this table exists year-round (preseason, offseason,
+ * bye weeks), so it's used whenever there's no active matchup to scrape.
+ */
+async function fetchOttoneuRosterPlayers(
+  teamUrl: string,
+  resolveSleeperId: SleeperIdResolver,
+  playersData: Record<string, SleeperPlayer>
+): Promise<Player[]> {
+  const res = await fetch(teamUrl);
+  if (!res.ok) {
+    return [];
+  }
+
+  const html = await res.text();
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  const rosterTable = Array.from(document.querySelectorAll('table')).find(
+    (table) => {
+      const headerTexts = Array.from(table.querySelectorAll('thead th'))
+        .map((th) => th.textContent?.trim().toLowerCase())
+        .filter(Boolean) as string[];
+      return headerTexts.includes('player') && headerTexts.includes('pos');
+    }
+  );
+
+  if (!rosterTable) {
+    return [];
+  }
+
+  const rows = Array.from(rosterTable.querySelectorAll('tbody tr'));
+
+  return rows
+    .map((row): Player | null => {
+      const playerCell = row.querySelector('td');
+      const anchor = playerCell?.querySelector('a[href*="/player_card/"]');
+      const name = anchor?.textContent?.trim() || '';
+      if (!name) {
+        return null;
+      }
+
+      const idMatch = (anchor?.getAttribute('href') || '').match(
+        /\/player_card\/nfl\/(\d+)/
+      );
+      const id = idMatch ? idMatch[1] : name;
+
+      const meta =
+        playerCell?.querySelector('.smaller')?.textContent?.trim() || '';
+      const metaParts = meta.split(' ').filter(Boolean);
+      const realTeam = metaParts[0] || '';
+      const metaPosition = metaParts.slice(1).join(' ');
+
+      const posCell = row.querySelectorAll('td')[1];
+      const posDisplay = posCell?.textContent?.trim() || '';
+
+      const sleeperId = resolveSleeperId(name);
+      const sleeperPosition = sleeperId
+        ? playersData[sleeperId]?.position
+        : undefined;
+      const position =
+        (sleeperPosition || '').toString().toUpperCase() ||
+        (metaPosition ? metaPosition.toUpperCase() : '') ||
+        posDisplay.toUpperCase() ||
+        '';
+
+      return {
+        id,
+        name,
+        position,
+        realTeam,
+        score: 0,
+        gameStatus: 'pregame',
+        gameStartTime: null,
+        gameQuarter: null,
+        gameClock: null,
+        onUserTeams: 0,
+        onOpponentTeams: 0,
+        gameDetails: { score: '', timeRemaining: '', fieldPosition: '' },
+        imageUrl: getSleeperHeadshotUrl(sleeperId),
+        onBench: false,
+      } satisfies Player;
+    })
+    .filter((player): player is Player => player !== null);
+}
+
+/**
  * Builds teams for an Ottoneu integration.
  * @param integration The Ottoneu integration record.
  * @returns A list of teams from Ottoneu.
@@ -1101,6 +1188,16 @@ export async function buildOttoneuTeams(
       }
     } catch (e) {
       console.error('Failed to fetch Ottoneu matchup page', e);
+    }
+  } else {
+    try {
+      userPlayers = await fetchOttoneuRosterPlayers(
+        `https://ottoneu.fangraphs.com/football/${league.league_id}/team/${integration.provider_user_id}`,
+        resolveSleeperId,
+        playersData
+      );
+    } catch (e) {
+      console.error('Failed to fetch Ottoneu roster page', e);
     }
   }
 


### PR DESCRIPTION
## Summary
- `buildOttoneuTeams` only pulled players by scraping the weekly matchup/game page. During preseason, offseason, and bye weeks there's no active matchup, so the player list came back empty even though the team and league info (parsed/persisted separately) still showed up — matching the reported symptom.
- Confirmed this is not a Cloudflare/user-agent bot-block issue: plain `fetch()` (no browser UA, same as Node's default) currently succeeds against both the team page and matchup page; a browser-style UA does trigger a Cloudflare challenge, but the app never sends one.
- Added `fetchOttoneuRosterPlayers`, which scrapes the team page's own roster table (`Player | POS | Salary | Bye | Pts`) — present year-round — and wired it in as a fallback whenever `info.matchup` is absent.

## Test plan
- [x] `npx jest src/app/actions.test.ts` — added a new case for the no-matchup roster-table fallback; all 25 tests pass
- [x] Verified the new parser against a live Ottoneu team page fetched via plain curl (12/12 roster players parsed correctly)
- [ ] CI Playwright report on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b1vEemAsjKQMizJ2qmd1Y