### PR TITLE
ci(mobile): add manual TestFlight release workflow

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,0 +1,59 @@
+name: Mobile Release (TestFlight)
+
+# Manual only — this builds a production iOS binary and submits it to
+# App Store Connect / TestFlight. Not something we want firing on every
+# push. Bump the version in apps/mobile/app.json before running this;
+# eas.json's autoIncrement handles the build number.
+on:
+  workflow_dispatch:
+    inputs:
+      what_to_test:
+        description: 'TestFlight "What to Test" notes for this build'
+        required: false
+        default: ''
+
+concurrency:
+  group: mobile-release
+  cancel-in-progress: false
+
+jobs:
+  build-and-submit:
+    runs-on: ubuntu-latest
+    # Configure this environment in repo Settings → Environments and add
+    # required reviewers if you want a manual approval gate before the
+    # build ships to Apple.
+    environment: ios-release
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Set up EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build iOS (production profile)
+        working-directory: apps/mobile
+        # Runs on EAS's servers, not the runner — env vars come from the
+        # "production" environment configured in the EAS dashboard, and
+        # iOS signing credentials come from the EAS credentials service.
+        run: eas build --platform ios --profile production --non-interactive --wait
+
+      - name: Submit to App Store Connect (TestFlight)
+        working-directory: apps/mobile
+        run: |
+          eas submit --platform ios --profile production --non-interactive --latest \
+            ${{ github.event.inputs.what_to_test != '' && format('--what-to-test "{0}"', github.event.inputs.what_to_test) || '' }}

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -252,6 +252,12 @@ npx eas-cli submit --profile production --platform ios
 # version," select the new build, and submit for review.
 ```
 
+Or trigger the **Mobile Release (TestFlight)** GitHub Action
+(`.github/workflows/mobile-release.yml`, `workflow_dispatch` only) from
+the Actions tab — it runs the same build + submit steps in CI using the
+`EXPO_TOKEN` secret and the credentials already stored on EAS's servers.
+Still bump the version in `app.json` and push that first.
+
 ## What's not here yet
 
 - **Integration management on mobile.** Connecting or removing Sleeper,


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/mobile-release.yml`, a `workflow_dispatch`-only Action that runs `eas build --platform ios --profile production` then `eas submit ... --latest` for TestFlight, using the existing `EXPO_TOKEN` secret (same one `mobile-preview.yml` uses).
- Gated behind an `ios-release` GitHub Environment so you can optionally require manual approval before it ships a build to Apple (configure reviewers under Settings → Environments once this merges).
- Notes the workflow in `docs/MOBILE.md`'s "Subsequent releases" section.

Manual-only by design — a production App Store submission isn't something that should fire on every push. You still bump `apps/mobile/app.json`'s version and push before triggering it; `eas.json`'s `autoIncrement` handles the build number.

## Note
The `eas submit` step will currently fail the same way the manual CLI submit did — App Store Connect is rejecting the submission with a generic error unrelated to this workflow (likely an Apple Program Agreement or API key issue on the ASC side, still being tracked down). The workflow itself is correct and will start working once that's resolved.

## Test plan
- [ ] Confirm `EXPO_TOKEN` secret has permission to trigger EAS builds/submits from CI (it's already used by `mobile-preview.yml`)
- [ ] After merge, configure the `ios-release` environment's required reviewers if a manual gate is wanted
- [ ] Once the ASC submission issue is fixed, run the workflow from the Actions tab to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)