### PR TITLE
fix(ottoneu): fix Ottoneu team missing on mobile app

### DIFF
--- a/apps/web/src/app/actions.test.ts
+++ b/apps/web/src/app/actions.test.ts
@@ -1015,6 +1015,43 @@ describe('actions', () => {
       expect(result.teams[0].opponent.totalScore).toBe(20);
     });
 
+    it('reads Ottoneu leagues with the caller-supplied client (mobile bearer-token requests carry no cookies)', async () => {
+      // Mirrors /api/teams/refresh: the mobile app authenticates via
+      // `Authorization: Bearer <jwt>` and getTeams() is called with an
+      // explicit client + userId instead of relying on the cookie-based
+      // default. getOttoneuLeagues must be called with that same client,
+      // not a fresh cookie-based one, or the RLS-scoped read silently
+      // returns zero rows and the Ottoneu team disappears on mobile.
+      const bearerClient: any = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockResolvedValue({
+          data: [{ id: 1, provider: 'ottoneu', provider_user_id: '2514' }],
+          error: null,
+        }),
+      };
+
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ week: 1 }) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockScoreboard) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+
+      (getOttoneuLeagues as jest.Mock).mockResolvedValue({
+        leagues: [{ league_id: '309' }],
+        error: null,
+      });
+      (getOttoneuTeamInfo as jest.Mock).mockResolvedValue({
+        teamName: 'My Team',
+        teamId: '2514',
+      });
+
+      await getTeams(bearerClient, 'user-1');
+
+      expect(getOttoneuLeagues).toHaveBeenCalledWith(1, bearerClient);
+      // The cookie-based default client must never be created for this call.
+      expect(createClient).not.toHaveBeenCalled();
+    });
+
     it('uses team-scores header when team appears on the away side', async () => {
       mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
       mockSupabase.eq.mockResolvedValue({

--- a/apps/web/src/app/actions.test.ts
+++ b/apps/web/src/app/actions.test.ts
@@ -685,6 +685,42 @@ describe('actions', () => {
       expect(result.teams[0].players[0].gameClock).toBe('5:10');
     });
 
+    it('reads Yahoo tokens/teams with the caller-supplied client and user id (mobile bearer-token requests carry no cookies)', async () => {
+      // Mirrors /api/teams/refresh: the mobile app authenticates via
+      // `Authorization: Bearer <jwt>` and getTeams() is called with an
+      // explicit client + userId instead of relying on the cookie-based
+      // default. getYahooUserTeams/buildYahooTeams must be called with
+      // that same client and the integration's user id, not fall back to
+      // a fresh cookie-based client and `supabase.auth.getUser()` (which
+      // can't resolve a session for a bearer-only client) - or the Yahoo
+      // team silently disappears on mobile the same way Ottoneu did.
+      const bearerClient: any = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockResolvedValue({
+          data: [{ id: 'int-2', provider: 'yahoo', user_id: 'user-1' }],
+          error: null,
+        }),
+      };
+
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ week: 1 }) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockScoreboard) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockPlayersData) });
+
+      (getYahooUserTeams as jest.Mock).mockResolvedValue({
+        teams: [],
+        error: null,
+        accessToken: 'token',
+      });
+
+      await getTeams(bearerClient, 'user-1');
+
+      expect(getYahooUserTeams).toHaveBeenCalledWith('int-2', bearerClient, 'user-1');
+      // The cookie-based default client must never be created for this call.
+      expect(createClient).not.toHaveBeenCalled();
+    });
+
     it('should continue if getLeagues returns an error', async () => {
       mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
       mockSupabase.eq.mockResolvedValue({

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -606,12 +606,13 @@ type YahooLeagueRow = {
  * @returns A map from Yahoo league key to the stored league row.
  */
 async function loadYahooLeagueLookup(
-  integrationId: number
+  integrationId: number,
+  client?: SupabaseClient
 ): Promise<Map<string, YahooLeagueRow>> {
   const lookupStart = startTimer();
 
   try {
-    const supabase = createClient();
+    const supabase = client ?? createClient();
     const { data, error } = await supabase
       .from('fp_leagues')
       .select('league_id, name, season, total_rosters')
@@ -657,7 +658,8 @@ export async function buildYahooTeams(
     | BuildYahooTeamsOptions
     | any[],
   accessTokenOrPrefetchedTeams?: string | any[],
-  prefetchedTeamsArg?: any[]
+  prefetchedTeamsArg?: any[],
+  client?: SupabaseClient
 ): Promise<Team[]> {
   let yahooApiTeams: any[] | undefined;
   let resolvedAccessToken: string | undefined;
@@ -700,7 +702,7 @@ export async function buildYahooTeams(
       teams: fetchedTeams,
       error: teamsError,
       accessToken: teamsAccessToken,
-    } = await getYahooUserTeams(integration.id);
+    } = await getYahooUserTeams(integration.id, client, integration.user_id);
 
     if (teamsError || !fetchedTeams) {
       return [];
@@ -714,7 +716,7 @@ export async function buildYahooTeams(
 
   if (!resolvedAccessToken) {
     const { access_token: freshToken, error: accessTokenError } =
-      await getYahooAccessToken(integration.id);
+      await getYahooAccessToken(integration.id, client, integration.user_id);
 
     if (accessTokenError || !freshToken) {
       console.error(
@@ -733,7 +735,7 @@ export async function buildYahooTeams(
   // Yahoo's team payload carries only a league_key, not the league's
   // name. Names were persisted to fp_leagues at connect time, so resolve
   // them in one indexed query rather than per team.
-  const leagueLookup = await loadYahooLeagueLookup(integration.id);
+  const leagueLookup = await loadYahooLeagueLookup(integration.id, client);
 
   const mapYahooPlayer = (
     player: any,
@@ -1356,7 +1358,7 @@ export async function getTeams(
           teams: yahooTeams,
           error: yahooTeamsError,
           accessToken,
-        } = await getYahooUserTeams(integration.id);
+        } = await getYahooUserTeams(integration.id, supabase, integration.user_id);
 
         if (yahooTeamsError || !yahooTeams) {
           return [] as Team[];
@@ -1367,7 +1369,8 @@ export async function getTeams(
           playerNameMap,
           week,
           accessToken,
-          yahooTeams
+          yahooTeams,
+          supabase
         );
       })();
     } else if (integration.provider === 'ottoneu') {

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -1002,9 +1002,10 @@ async function fetchOttoneuRosterPlayers(
 export async function buildOttoneuTeams(
   integration: any,
   playerNameMap: { [key: string]: string },
-  playersData: Record<string, SleeperPlayer>
+  playersData: Record<string, SleeperPlayer>,
+  client?: SupabaseClient
 ): Promise<Team[]> {
-  const { leagues, error } = await getOttoneuLeagues(integration.id);
+  const { leagues, error } = await getOttoneuLeagues(integration.id, client);
   if (error || !leagues || leagues.length === 0) {
     return [];
   }
@@ -1373,7 +1374,8 @@ export async function getTeams(
       builderPromise = teamBuilders.buildOttoneuTeams(
         integration,
         playerNameMap,
-        playersData
+        playersData,
+        supabase
       );
     }
 

--- a/apps/web/src/app/integrations/ottoneu/actions.ts
+++ b/apps/web/src/app/integrations/ottoneu/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabase/server';
 import { JSDOM } from 'jsdom';
 
@@ -384,9 +385,17 @@ export async function getOttoneuIntegration() {
 /**
  * Gets leagues linked to an integration.
  * @param integrationId - The integration ID.
+ * @param client - Supabase client to query with. Defaults to the
+ * cookie-based server client; callers authenticated via a bearer token
+ * (e.g. the mobile app's `/api/teams/refresh` requests, which carry no
+ * cookies) must pass their own client so this RLS-scoped read resolves
+ * to the right user instead of silently returning zero rows.
  */
-export async function getLeagues(integrationId: number) {
-  const supabase = createClient();
+export async function getLeagues(
+  integrationId: number,
+  client?: SupabaseClient
+) {
+  const supabase = client ?? createClient();
   const { data, error } = await supabase
     .from('fp_leagues')
     .select('*')

--- a/apps/web/src/app/integrations/yahoo/actions.ts
+++ b/apps/web/src/app/integrations/yahoo/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 import { createClient } from '@/utils/supabase/server';
 import { getCurrentNflWeek } from '@/app/actions';
@@ -38,23 +39,39 @@ function logYahooApiDuration(
 /**
  * Gets the Yahoo access token for an integration.
  * @param integrationId - The ID of the integration.
+ * @param client - Supabase client to query with. Defaults to the
+ * cookie-based server client; callers authenticated via a bearer token
+ * (e.g. the mobile app's `/api/teams/refresh` requests, which carry no
+ * cookies) must pass their own client, since `supabase.auth.getUser()`
+ * with no argument can't resolve a session from a bearer-only client.
+ * @param userId - The authenticated user's id. When provided, skips the
+ * `supabase.auth.getUser()` cookie-session lookup (which bearer-token
+ * clients can't satisfy) and scopes the query directly.
  * @returns The access token or an error.
  */
-export async function getYahooAccessToken(integrationId: number): Promise<{ access_token?: string; error?: string }> {
-  const supabase = createClient();
+export async function getYahooAccessToken(
+  integrationId: number,
+  client?: SupabaseClient,
+  userId?: string
+): Promise<{ access_token?: string; error?: string }> {
+  const supabase = client ?? createClient();
   logger.info(`Fetching access token for integrationId: ${integrationId}`);
 
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    logger.error('Authentication error: No user found.');
-    return { error: 'User not authenticated.' };
+  let resolvedUserId = userId;
+  if (!resolvedUserId) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      logger.error('Authentication error: No user found.');
+      return { error: 'User not authenticated.' };
+    }
+    resolvedUserId = user.id;
   }
 
   const { data: integration, error: integrationError } = await supabase
     .from('fp_user_integrations')
     .select('access_token, refresh_token, expires_at')
     .eq('id', integrationId)
-    .eq('user_id', user.id)
+    .eq('user_id', resolvedUserId)
     .single();
 
   if (integrationError) {
@@ -63,7 +80,7 @@ export async function getYahooAccessToken(integrationId: number): Promise<{ acce
   }
 
   if (!integration) {
-    logger.error(`Integration not found for id: ${integrationId} and user_id: ${user.id}`);
+    logger.error(`Integration not found for id: ${integrationId} and user_id: ${resolvedUserId}`);
     return { error: 'Yahoo integration not found.' };
   }
 
@@ -252,10 +269,18 @@ export async function getTeams(integrationId: number) {
  *   }
  * }
  * @param integrationId - The ID of the integration.
+ * @param client - Supabase client to query/upsert with. See
+ * {@link getYahooAccessToken} for why bearer-token callers must pass one.
+ * @param userId - The authenticated user's id, forwarded to
+ * {@link getYahooAccessToken}.
  * @returns A list of teams or an error.
  */
-export async function getYahooUserTeams(integrationId: number) {
-  const { access_token, error: tokenError } = await getYahooAccessToken(integrationId);
+export async function getYahooUserTeams(
+  integrationId: number,
+  client?: SupabaseClient,
+  userId?: string
+) {
+  const { access_token, error: tokenError } = await getYahooAccessToken(integrationId, client, userId);
   if (tokenError || !access_token) {
     return { error: tokenError || 'Failed to get Yahoo access token.' };
   }
@@ -303,7 +328,7 @@ export async function getYahooUserTeams(integrationId: number) {
     });
 
     if (teamsToInsert.length > 0) {
-      const supabase = createClient();
+      const supabase = client ?? createClient();
       const { data: upsertedTeams, error: upsertError } = await supabase
         .from('fp_teams')
         .upsert(teamsToInsert, { onConflict: 'team_key,user_integration_id' })


### PR DESCRIPTION
## Summary

Ottoneu (and, it turns out, Yahoo) integration data was showing up on the web dashboard but silently disappearing on the mobile app for the same user.

**Root cause:** both `getOttoneuLeagues` and `getYahooAccessToken`/`getYahooUserTeams` built their own cookie-based Supabase client (`createClient()` from `@/utils/supabase/server`) instead of using the client `getTeams()` had already resolved for the current request.

- Web calls carry the Supabase auth cookie, so that client works.
- Mobile calls `/api/teams/refresh` with `Authorization: Bearer <jwt>` and **no cookies**.
  - For Ottoneu: the cookie-based client was unauthenticated, so the RLS-scoped `fp_leagues` read returned zero rows. `buildOttoneuTeams` treats "no leagues" the same as "no integration" and returns `[]`.
  - For Yahoo: `getYahooAccessToken` calls `supabase.auth.getUser()` with no argument, which can't resolve a session on a bearer-only client (no cookies, no persisted session) — it returned `"User not authenticated."` and the team was dropped the same way.

Both failures are silent: only a server-side log, no visible error, no crash — the team just isn't in the response.

**Fix:**
- `getOttoneuLeagues`/`buildOttoneuTeams` now accept the already-resolved Supabase client and use it instead of creating a new cookie-based one.
- `getYahooAccessToken`/`getYahooUserTeams`/`buildYahooTeams` now accept an optional client *and* user id; when a user id is supplied they skip the `auth.getUser()` cookie-session lookup entirely and scope the query directly, since `getTeams()` already knows the user id for either auth mode (bearer or cookie).
- `getTeams()` passes its `supabase` client (correctly bearer- or cookie-authenticated) and the integration's own `user_id` through to both builders.

## Test plan

- [x] Added a unit test for each provider asserting the builder is called with the caller-supplied (bearer) client — and that the cookie-based `createClient()` is never invoked — when `getTeams()` is called the way `/api/teams/refresh` calls it for mobile requests.
- [x] `npx jest src/app/actions.test.ts` — 27/27 passing.
- [x] `npx jest src/app/integrations/yahoo/actions.test.ts` — 4/4 passing (existing cookie-based single-arg calls still work unchanged).
- [x] `npx jest` (apps/web) — 210/210 executed tests passing (2 unrelated pre-existing suite failures from missing `@radix-ui/*` deps in this environment, not touched by this change).
- [ ] Manual check on a real device against a deployed preview once CI is up, to confirm the Ottoneu and Yahoo teams now render in the app for an affected account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BQT47wEJJKCVEt4GHnjgo