### PR TITLE
ci(mobile): auto-increment minor version in the release workflow

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -2,8 +2,9 @@ name: Mobile Release (TestFlight)
 
 # Manual only — this builds a production iOS binary and submits it to
 # App Store Connect / TestFlight. Not something we want firing on every
-# push. Bump the version in apps/mobile/app.json before running this;
-# eas.json's autoIncrement handles the build number.
+# push. The workflow auto-increments the minor version in
+# apps/mobile/app.json (and commits the bump back to the branch) before
+# building; eas.json's autoIncrement handles the build number.
 on:
   workflow_dispatch:
     inputs:
@@ -24,7 +25,7 @@ jobs:
     # build ships to Apple.
     environment: ios-release
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -44,6 +45,26 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+
+      - name: Bump minor version
+        working-directory: apps/mobile
+        run: |
+          node -e '
+            const fs = require("fs");
+            const config = JSON.parse(fs.readFileSync("app.json", "utf8"));
+            const [major, minor] = config.expo.version.split(".").map(Number);
+            config.expo.version = `${major}.${minor + 1}.0`;
+            fs.writeFileSync("app.json", JSON.stringify(config, null, 2) + "\n");
+            console.log(`Bumped version to ${config.expo.version}`);
+          '
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/mobile/app.json
+          git commit -m "chore(mobile): bump version to $(node -p "require('./apps/mobile/app.json').expo.version")"
+          git push
 
       - name: Build iOS (production profile)
         working-directory: apps/mobile

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Roster Loom",
     "slug": "roster-loom",
-    "version": "0.1.0",
+    "version": "0.3.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "rosterloom",

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -256,7 +256,9 @@ Or trigger the **Mobile Release (TestFlight)** GitHub Action
 (`.github/workflows/mobile-release.yml`, `workflow_dispatch` only) from
 the Actions tab — it runs the same build + submit steps in CI using the
 `EXPO_TOKEN` secret and the credentials already stored on EAS's servers.
-Still bump the version in `app.json` and push that first.
+It auto-increments the minor version in `app.json` (e.g. 0.2.0 → 0.3.0)
+and commits that bump back to the branch before building, so there's
+nothing to bump by hand first.
 
 ## What's not here yet
 


### PR DESCRIPTION
## Summary
- The **Mobile Release (TestFlight)** workflow (`.github/workflows/mobile-release.yml`) now auto-increments the minor version (`major.minor.0`) in `apps/mobile/app.json` and commits that bump back to the branch before running `eas build`. Build number auto-increment (`eas.json` → `autoIncrement: true`) is unchanged.
- Bumps the current app version from `0.1.0` to `0.3.0`.
- Updates `docs/MOBILE.md` to reflect that the version no longer needs to be bumped by hand before triggering the Action.

## Test plan
- [ ] Trigger the `Mobile Release (TestFlight)` workflow via `workflow_dispatch` and confirm `apps/mobile/app.json`'s version is bumped and committed before the build step runs.
- [ ] Confirm the resulting EAS build picks up the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrSHJ6e7uFyCaXqfzw31Nj