### PR TITLE
ci(mobile): push version bump with a PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -30,6 +30,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # The default GITHUB_TOKEN (github-actions[bot]) can't push to
+          # main — it isn't on the ruleset's bypass list, and that list
+          # can't include the GitHub Actions app itself on a personal
+          # (non-org) repo. RELEASE_PUSH_TOKEN is a fine-grained PAT from
+          # an admin account with Contents: read/write on this repo, so
+          # the "Commit version bump" push below qualifies for the
+          # ruleset's admin bypass instead.
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -260,6 +260,20 @@ It auto-increments the minor version in `app.json` (e.g. 0.2.0 → 0.3.0)
 and commits that bump back to the branch before building, so there's
 nothing to bump by hand first.
 
+**One-time setup for the version-bump commit.** `main` is protected by
+a ruleset that blocks direct pushes, and the default `GITHUB_TOKEN`
+can't be added to its bypass list (that only works for org-owned
+repos). So the workflow pushes using a `RELEASE_PUSH_TOKEN` secret
+instead:
+1. Add a `RepositoryRole: Admin` bypass actor to the `main` ruleset
+   (**Settings → Rules → Rulesets → main → Bypass list**), so an admin
+   push can skip the PR requirement.
+2. Create a fine-grained PAT from an admin account, scoped to this
+   repo only, with **Contents: Read and write** permission.
+3. Add it as a repo secret named `RELEASE_PUSH_TOKEN`
+   (**Settings → Secrets and variables → Actions → New repository
+   secret**).
+
 ## What's not here yet
 
 - **Integration management on mobile.** Connecting or removing Sleeper,


### PR DESCRIPTION
## Summary
Follow-up to #219. The default `GITHUB_TOKEN` (`github-actions[bot]`) can't push directly to `main` — the branch ruleset blocks non-PR pushes, and `Integration`-type bypass actors aren't available on personal (non-org) repos (confirmed: PATCHing the ruleset with an `Integration` bypass actor 404s). Switches the release workflow's checkout to use a `RELEASE_PUSH_TOKEN` PAT from an admin account instead, and documents the one-time setup in `docs/MOBILE.md`.

## Setup still required (not part of this PR)
- Add a `RepositoryRole: Admin` bypass actor to the `main` ruleset (Settings → Rules → Rulesets → main → Bypass list)
- Create a fine-grained PAT (this repo only, Contents: read/write) and add it as repo secret `RELEASE_PUSH_TOKEN`

## Test plan
- [ ] Once the PAT/secret and ruleset bypass are set up, trigger `Mobile Release (TestFlight)` via `workflow_dispatch` and confirm the version-bump commit pushes successfully to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrSHJ6e7uFyCaXqfzw31Nj