### PR TITLE
fix(sleeper): dedupe leagues to prevent duplicate scoreboards

### DIFF
--- a/apps/web/src/app/actions.test.ts
+++ b/apps/web/src/app/actions.test.ts
@@ -250,6 +250,29 @@ describe('actions', () => {
       expect(getCurrentSleeperLeagues).toHaveBeenCalledWith('sleeper-user-1');
     });
 
+    it('dedupes leagues that Sleeper lists more than once', async () => {
+      (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({
+        leagues: [
+          { id: 1, league_id: 'sleeper-league-1' },
+          { id: 1, league_id: 'sleeper-league-1' },
+        ],
+        error: null,
+      });
+
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockRosters) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockMatchups) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockLeagueUsers) });
+
+      const result = await buildSleeperTeams(
+        { id: 1, provider_user_id: 'sleeper-user-1' },
+        1,
+        { playersData: mockPlayersData, playerNameMap: {} }
+      );
+
+      expect(result).toHaveLength(1);
+    });
+
     it('skips leagues when sleeper data is incomplete', async () => {
       (getCurrentSleeperLeagues as jest.Mock).mockResolvedValue({
         leagues: [{ id: 1, league_id: 'sleeper-league-1' }],

--- a/apps/web/src/app/actions.ts
+++ b/apps/web/src/app/actions.ts
@@ -478,7 +478,16 @@ export async function buildSleeperTeams(
 
   const teams: Team[] = [];
 
-  for (const league of leagues as SleeperLeague[]) {
+  // Sleeper can list the same league_id more than once (e.g. when the user
+  // manages two rosters in it), which would otherwise produce duplicate
+  // scoreboards and double-count that league's players in aggregated views.
+  const uniqueLeagues = Array.from(
+    new Map(
+      (leagues as SleeperLeague[]).map((league) => [league.league_id, league])
+    ).values()
+  );
+
+  for (const league of uniqueLeagues) {
     const [rosters, matchups, leagueUsers] = await Promise.all([
       fetch(`https://api.sleeper.app/v1/league/${league.league_id}/rosters`).then(
         (response) => response.json() as Promise<SleeperRoster[]>


### PR DESCRIPTION
## Summary
- One Sleeper league could show up twice on the dashboard/mobile scoreboard with duplicate matchups and duplicate players in aggregated views (Fantasy Heroes).
- Root cause: Sleeper's `/v1/user/{id}/leagues/nfl/{season}` endpoint can list the same `league_id` more than once (e.g. when the user manages two rosters in that league). `buildSleeperTeams` looped over every entry with no dedup, producing two identical `Team` objects for the same league.
- Fix: dedupe leagues by `league_id` before building teams in `buildSleeperTeams` (`apps/web/src/app/actions.ts`).

## Test plan
- [x] Added a regression test in `apps/web/src/app/actions.test.ts` covering a Sleeper response with a duplicated league entry — asserts only one `Team` is built.
- [x] `npm test --workspace=apps/web` — 224/224 passing.
- [x] CI Playwright report on the PR (per repo policy, not run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZCQyTmigirXRQaw6suKJh